### PR TITLE
Change `type` to `brand`

### DIFF
--- a/lib/stripe/models/payment_method.rb
+++ b/lib/stripe/models/payment_method.rb
@@ -25,7 +25,7 @@ module Killbill #:nodoc:
                   :token              => card_response['id'],
                   :cc_first_name      => card_response['name'],
                   :cc_last_name       => nil,
-                  :cc_type            => card_response['type'],
+                  :cc_type            => card_response['brand'],
                   :cc_exp_month       => card_response['exp_month'],
                   :cc_exp_year        => card_response['exp_year'],
                   :cc_last_4          => card_response['last4'],


### PR DESCRIPTION
In Stripe's API, they use `card.brand`, not `card.type`. Changing the key here allows the card type to be properly captured.