### PR TITLE
healthcheck: make healthcheck work without tenant headers

### DIFF
--- a/src/main/java/org/killbill/billing/plugin/stripe/StripeHealthcheck.java
+++ b/src/main/java/org/killbill/billing/plugin/stripe/StripeHealthcheck.java
@@ -47,8 +47,14 @@ public class StripeHealthcheck implements Healthcheck {
 
     @Override
     public HealthStatus getHealthStatus(@Nullable final Tenant tenant, @Nullable final Map properties) {
-        final StripeConfigProperties stripeConfigProperties = stripeConfigPropertiesConfigurationHandler.getConfigurable(tenant == null ? null : tenant.getId());
-        return pingStripe(stripeConfigProperties);
+        if (tenant == null) {
+            // The plugin is running
+            return HealthStatus.healthy("Stripe OK");
+        } else {
+            // Specifying the tenant lets you also validate the tenant configuration
+            final StripeConfigProperties stripeConfigProperties = stripeConfigPropertiesConfigurationHandler.getConfigurable(tenant.getId());
+            return pingStripe(stripeConfigProperties);
+        }
     }
 
     private HealthStatus pingStripe(final StripeConfigProperties stripeConfigProperties) {

--- a/src/test/java/org/killbill/billing/plugin/stripe/TestStripeHealthcheck.java
+++ b/src/test/java/org/killbill/billing/plugin/stripe/TestStripeHealthcheck.java
@@ -16,11 +16,22 @@
 
 package org.killbill.billing.plugin.stripe;
 
+import java.util.Properties;
+
 import org.killbill.billing.osgi.api.Healthcheck;
+import org.killbill.billing.plugin.TestUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 public class TestStripeHealthcheck extends TestBase {
+
+    @Test(groups = "slow")
+    public void testHealthcheckNoTenant() {
+        final StripeConfigPropertiesConfigurationHandler noConfigHandler = new StripeConfigPropertiesConfigurationHandler(StripeActivator.PLUGIN_NAME, killbillApi, TestUtils.buildLogService(), null);
+        noConfigHandler.setDefaultConfigurable(new StripeConfigProperties(new Properties(), ""));
+        final Healthcheck healthcheck = new StripeHealthcheck(noConfigHandler);
+        Assert.assertTrue(healthcheck.getHealthStatus(null, null).isHealthy());
+    }
 
     @Test(groups = "slow")
     public void testHealthcheck() {


### PR DESCRIPTION
This is useful for load balancers for instance.
