### PR TITLE
added support for more fields to checkout

### DIFF
--- a/src/main/java/org/killbill/billing/plugin/stripe/StripeCheckoutServlet.java
+++ b/src/main/java/org/killbill/billing/plugin/stripe/StripeCheckoutServlet.java
@@ -59,10 +59,21 @@ public class StripeCheckoutServlet extends PluginHealthcheck {
 
     @POST
     public Result createSession(@Named("kbAccountId") final UUID kbAccountId,
-                                @Named("successUrl") final Optional<String> successUrl,
+					            @Named("successUrl") final Optional<String> successUrl,
+					            @Named("cancelUrl") final Optional<String> cancelUrl,
+					            @Named("name") final Optional<String> line_item_name,
+					            @Named("kbaccount") final Optional<String> kbaccount,
+					            @Named("kbinvoice") final Optional<String> kbinvoice,
+					            @Named("amount") final Optional<Integer> amount,
                                 @Local @Named("killbill_tenant") final Tenant tenant) throws JsonProcessingException, PaymentPluginApiException {
         final CallContext context = new PluginCallContext(StripeActivator.PLUGIN_NAME, clock.getClock().getUTCNow(), kbAccountId, tenant.getId());
-        final ImmutableList<PluginProperty> customFields = ImmutableList.of(new PluginProperty("success_url", successUrl.orElse("https://example.com/success"), false));
+        final ImmutableList<PluginProperty> customFields = ImmutableList.of(
+        		new PluginProperty("kbaccount", kbaccount.orElse("none"), false),
+        		new PluginProperty("kbinvoice", kbinvoice.orElse("none"), false),
+        		new PluginProperty("success_url", successUrl.orElse("https://example.com/success"), false),
+        		new PluginProperty("cancel_url", successUrl.orElse("https://example.com/cancel"), false),
+        		new PluginProperty("line_item_name", line_item_name.orElse("Authorization charge"), false),
+        		new PluginProperty("line_item_amount", amount.orElse(100), false));
         final HostedPaymentPageFormDescriptor hostedPaymentPageFormDescriptor = stripePaymentPluginApi.buildFormDescriptor(kbAccountId,
                                                                                                                            customFields,
                                                                                                                            ImmutableList.of(),

--- a/src/main/java/org/killbill/billing/plugin/stripe/StripeCheckoutServlet.java
+++ b/src/main/java/org/killbill/billing/plugin/stripe/StripeCheckoutServlet.java
@@ -59,20 +59,19 @@ public class StripeCheckoutServlet extends PluginHealthcheck {
 
     @POST
     public Result createSession(@Named("kbAccountId") final UUID kbAccountId,
-					            @Named("successUrl") final Optional<String> successUrl,
-					            @Named("cancelUrl") final Optional<String> cancelUrl,
-					            @Named("name") final Optional<String> line_item_name,
-					            @Named("kbaccount") final Optional<String> kbaccount,
-					            @Named("kbinvoice") final Optional<String> kbinvoice,
-					            @Named("amount") final Optional<Integer> amount,
+                                @Named("successUrl") final Optional<String> successUrl,
+                                @Named("cancelUrl") final Optional<String> cancelUrl,
+                                @Named("name") final Optional<String> lineItemName,
+                                @Named("kbinvoice") final Optional<String> kbInvoiceId,
+                                @Named("amount") final Optional<Integer> amount,
                                 @Local @Named("killbill_tenant") final Tenant tenant) throws JsonProcessingException, PaymentPluginApiException {
         final CallContext context = new PluginCallContext(StripeActivator.PLUGIN_NAME, clock.getClock().getUTCNow(), kbAccountId, tenant.getId());
         final ImmutableList<PluginProperty> customFields = ImmutableList.of(
-        		new PluginProperty("kbaccount", kbaccount.orElse("none"), false),
-        		new PluginProperty("kbinvoice", kbinvoice.orElse("none"), false),
+        		new PluginProperty("kbaccount", kbAccountId.toString(), false),
+        		new PluginProperty("kbinvoice", kbInvoiceId.orElse(null), false),
         		new PluginProperty("success_url", successUrl.orElse("https://example.com/success"), false),
         		new PluginProperty("cancel_url", successUrl.orElse("https://example.com/cancel"), false),
-        		new PluginProperty("line_item_name", line_item_name.orElse("Authorization charge"), false),
+        		new PluginProperty("line_item_name", lineItemName.orElse("Authorization charge"), false),
         		new PluginProperty("line_item_amount", amount.orElse(100), false));
         final HostedPaymentPageFormDescriptor hostedPaymentPageFormDescriptor = stripePaymentPluginApi.buildFormDescriptor(kbAccountId,
                                                                                                                            customFields,

--- a/src/main/java/org/killbill/billing/plugin/stripe/StripeConfigProperties.java
+++ b/src/main/java/org/killbill/billing/plugin/stripe/StripeConfigProperties.java
@@ -44,6 +44,7 @@ public class StripeConfigProperties {
 
     private final String region;
     private final String apiKey;
+    private final String publicKey;
     private final String connectionTimeout;
     private final String readTimeout;
     private final Period pendingPaymentExpirationPeriod;
@@ -56,6 +57,7 @@ public class StripeConfigProperties {
     public StripeConfigProperties(final Properties properties, final String region) {
         this.region = region;
         this.apiKey = properties.getProperty(PROPERTY_PREFIX + "apiKey");
+        this.publicKey = properties.getProperty(PROPERTY_PREFIX + "publicKey");
         this.connectionTimeout = properties.getProperty(PROPERTY_PREFIX + "connectionTimeout", DEFAULT_CONNECTION_TIMEOUT);
         this.readTimeout = properties.getProperty(PROPERTY_PREFIX + "readTimeout", DEFAULT_READ_TIMEOUT);
         this.pendingPaymentExpirationPeriod = readPendingExpirationProperty(properties);
@@ -67,6 +69,10 @@ public class StripeConfigProperties {
 
     public String getApiKey() {
         return apiKey;
+    }
+
+    public String getPublicKey() {
+        return publicKey;
     }
 
     public String getConnectionTimeout() {

--- a/src/main/java/org/killbill/billing/plugin/stripe/StripePaymentPluginApi.java
+++ b/src/main/java/org/killbill/billing/plugin/stripe/StripePaymentPluginApi.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.StreamSupport;
 
 import javax.annotation.Nullable;
 
@@ -91,6 +92,13 @@ public class StripePaymentPluginApi extends PluginPaymentPluginApi<StripeRespons
 
     private final StripeConfigPropertiesConfigurationHandler stripeConfigPropertiesConfigurationHandler;
     private final StripeDao dao;
+    
+    final static List<String> metadataFilter = ImmutableList.of(
+    		"line_item_name",
+    		"line_item_amount",
+    		"line_item_currency",
+    		"line_item_quantity");
+
 
     public StripePaymentPluginApi(final StripeConfigPropertiesConfigurationHandler stripeConfigPropertiesConfigurationHandler,
                                   final OSGIKillbillAPI killbillAPI,
@@ -623,7 +631,9 @@ public class StripePaymentPluginApi extends PluginPaymentPluginApi<StripeRespons
 
         Map<String, Object> params = new HashMap<String, Object>();
         Map<String, Object> metadata = new HashMap<String, Object>();
-        customFields.forEach(p -> metadata.put(p.getKey(), p.getValue()));
+        StreamSupport.stream(customFields.spliterator(), false)
+        	.filter(entry -> !metadataFilter.contains(entry.getKey()))
+        	.forEach(p -> metadata.put(p.getKey(), p.getValue()));
         params.put("metadata", metadata);
         
         // Stripe doesn't support anything else yet

--- a/src/main/java/org/killbill/billing/plugin/stripe/StripePluginProperties.java
+++ b/src/main/java/org/killbill/billing/plugin/stripe/StripePluginProperties.java
@@ -215,7 +215,7 @@ public abstract class StripePluginProperties {
         return additionalDataMap;
     }
 
-    public static Map<String, Object> toAdditionalDataMap(final Session session, String pk) {
+    public static Map<String, Object> toAdditionalDataMap(final Session session, final String pk) {
         final Map<String, Object> additionalDataMap = new HashMap<String, Object>();
 
         additionalDataMap.put("billing_address_collection", session.getBillingAddressCollection());

--- a/src/main/java/org/killbill/billing/plugin/stripe/StripePluginProperties.java
+++ b/src/main/java/org/killbill/billing/plugin/stripe/StripePluginProperties.java
@@ -215,7 +215,7 @@ public abstract class StripePluginProperties {
         return additionalDataMap;
     }
 
-    public static Map<String, Object> toAdditionalDataMap(final Session session) {
+    public static Map<String, Object> toAdditionalDataMap(final Session session, String pk) {
         final Map<String, Object> additionalDataMap = new HashMap<String, Object>();
 
         additionalDataMap.put("billing_address_collection", session.getBillingAddressCollection());
@@ -231,6 +231,7 @@ public abstract class StripePluginProperties {
         additionalDataMap.put("payment_method_types", session.getPaymentMethodTypes());
         additionalDataMap.put("subscription_id", session.getSubscription());
         additionalDataMap.put("success_url", session.getSuccessUrl());
+        additionalDataMap.put("publishable_key", pk);
 
         return additionalDataMap;
     }

--- a/src/main/java/org/killbill/billing/plugin/stripe/dao/StripeDao.java
+++ b/src/main/java/org/killbill/billing/plugin/stripe/dao/StripeDao.java
@@ -126,7 +126,7 @@ public class StripeDao extends PluginPaymentDao<StripeResponsesRecord, StripeRes
                               final Session stripeSession,
                               final DateTime utcNow,
                               final UUID kbTenantId) throws SQLException {
-        final Map<String, Object> additionalDataMap = StripePluginProperties.toAdditionalDataMap(stripeSession);
+        final Map<String, Object> additionalDataMap = StripePluginProperties.toAdditionalDataMap(stripeSession,"");
 
         execute(dataSource.getConnection(),
                 new WithConnectionCallback<Void>() {


### PR DESCRIPTION
This is to allow one-off charges to be processed without using a payment method. Specifically I've added a line item name and line item amount to the plugin properties with defaults to keep the existing values if not supplied. This makes the HPP show the text and amount I wanted.
I also added the kbaccount and kbinvoice to the properties because they end up being useful when I process the success scenario.
Finally I also added the cancel_url property, which is documented in Stripe though I haven't used it yet.