### PR TITLE
Add option to fail payment that has failed 3DS authorization

### DIFF
--- a/src/main/java/org/killbill/billing/plugin/stripe/StripeConfigProperties.java
+++ b/src/main/java/org/killbill/billing/plugin/stripe/StripeConfigProperties.java
@@ -14,7 +14,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package org.killbill.billing.plugin.stripe;
 
 import java.util.HashMap;
@@ -55,6 +54,7 @@ public class StripeConfigProperties {
     private final Map<String, Period> paymentMethodToExpirationPeriod = new LinkedHashMap<String, Period>();
     private final String chargeDescription;
     private final String chargeStatementDescriptor;
+    private final boolean cancelOn3DSAuthorizationFailure;
 
     public StripeConfigProperties(final Properties properties, final String region) {
         this.region = region;
@@ -67,6 +67,7 @@ public class StripeConfigProperties {
         this.pendingHppPaymentWithoutCompletionExpirationPeriod = readPendingHppPaymentWithoutCompletionExpirationPeriod(properties);
         this.chargeDescription = Ascii.truncate(MoreObjects.firstNonNull(properties.getProperty(PROPERTY_PREFIX + "chargeDescription"), "Kill Bill charge"), 22, "...");
         this.chargeStatementDescriptor = Ascii.truncate(MoreObjects.firstNonNull(properties.getProperty(PROPERTY_PREFIX + "chargeStatementDescriptor"), "Kill Bill charge"), 22, "...");
+        this.cancelOn3DSAuthorizationFailure = readCancelOn3DSAuthorizationFailure(properties);
     }
 
     public String getApiKey() {
@@ -91,6 +92,10 @@ public class StripeConfigProperties {
 
     public String getChargeStatementDescriptor() {
         return chargeStatementDescriptor;
+    }
+
+    public boolean isCancelOn3DSAuthorizationFailure() {
+        return cancelOn3DSAuthorizationFailure;
     }
 
     public Period getPendingPaymentExpirationPeriod(@Nullable final String paymentMethod) {
@@ -150,6 +155,12 @@ public class StripeConfigProperties {
         }
 
         return Period.parse(DEFAULT_PENDING_HPP_PAYMENT_WITHOUT_COMPLETION_EXPIRATION_PERIOD);
+    }
+
+    private boolean readCancelOn3DSAuthorizationFailure(Properties properties) {
+        return Boolean.parseBoolean(
+                properties.getProperty(PROPERTY_PREFIX + "cancelOn3DSAuthorizationFailure")
+        );
     }
 
     private synchronized void refillMap(final Map<String, String> map, final String stringToSplit) {

--- a/src/main/java/org/killbill/billing/plugin/stripe/StripePaymentTransactionInfoPlugin.java
+++ b/src/main/java/org/killbill/billing/plugin/stripe/StripePaymentTransactionInfoPlugin.java
@@ -80,12 +80,19 @@ public class StripePaymentTransactionInfoPlugin extends PluginPaymentTransaction
         } else if ("pending".equals(lastChargeStatus)) {
             // Untestable - see https://stripe.com/docs/ach#ach-payments-workflow
             return PaymentPluginStatus.PENDING;
-        } else if (lastChargeStatus == null && "requires_action".equals(status)) {
-            // 3DS
-            return PaymentPluginStatus.PENDING;
         } else if ("failed".equals(lastChargeStatus)) {
             // TODO Do better (look at the type of error to narrow down on CANCELED)!
             return PaymentPluginStatus.ERROR;
+        } else if (lastChargeStatus == null) {
+            if ("requires_action".equals(status)) {
+                // 3DS
+                return PaymentPluginStatus.PENDING;
+            }
+            if ("canceled".equals(status)) {
+                // Intent has been cancelled, mark this as error.
+                return PaymentPluginStatus.ERROR;
+            }
+            return PaymentPluginStatus.UNDEFINED;
         } else {
             return PaymentPluginStatus.UNDEFINED;
         }

--- a/src/test/java/org/killbill/billing/plugin/stripe/TestStripePaymentPluginApi.java
+++ b/src/test/java/org/killbill/billing/plugin/stripe/TestStripePaymentPluginApi.java
@@ -576,7 +576,11 @@ public class TestStripePaymentPluginApi extends TestBase {
                                                                                                                                context);
         // Pending PaymentPluginStatus change to CANCELED from ERROR
         // Related: https://github.com/killbill/killbill-stripe-plugin/pull/33
-        assertEquals(paymentTransactionInfoPluginRefreshed.get(0).getStatus(), PaymentPluginStatus.ERROR);
+        if (super.stripeConfigPropertiesConfigurationHandler.getConfigurable(super.context.getTenantId()).isCancelOn3DSAuthorizationFailure()) {
+            assertEquals(paymentTransactionInfoPluginRefreshed.get(0).getStatus(), PaymentPluginStatus.ERROR);
+        } else {
+            assertEquals(paymentTransactionInfoPluginRefreshed.get(0).getStatus(), PaymentPluginStatus.PENDING);
+        }
     }
 
     @Test(groups = "integration", enabled = false, description = "Manual test")


### PR DESCRIPTION
Added an option to fail payments that have been detected as authorization_failure on 3DSecure payment methods on payment refresh.

Related discussion: [Killbill user groups](https://groups.google.com/g/killbilling-users/c/VOXBiJ50Ojw)