### PR TITLE
Add "ach_debit" payment method option only for USD

### DIFF
--- a/src/main/java/org/killbill/billing/plugin/stripe/StripePaymentPluginApi.java
+++ b/src/main/java/org/killbill/billing/plugin/stripe/StripePaymentPluginApi.java
@@ -760,7 +760,7 @@ public class StripePaymentPluginApi extends PluginPaymentPluginApi<StripeRespons
 
                                                  final ImmutableList.Builder<String> paymentMethodTypesBuilder = ImmutableList.builder();
                                                  paymentMethodTypesBuilder.add("card");
-                                                 if (transactionType == TransactionType.PURCHASE) {
+                                                 if (transactionType == TransactionType.PURCHASE && currency == Currency.USD) {
                                                      // See https://groups.google.com/forum/?#!msg/killbilling-users/li3RNs-YmIA/oaUrBElMFQAJ
                                                      paymentMethodTypesBuilder.add("ach_debit");
                                                  }


### PR DESCRIPTION
[Stripe docs:](https://stripe.com/docs/ach) "ACH is currently supported only for Stripe businesses based in the U.S.". Adding it to other currencies may result in failure (as is happened with me and EUR).

You can find the details at https://groups.google.com/g/killbilling-users/c/5Get6Of4idE 