### PR TITLE
Upgrade stripe-java to 20.33.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A full end-to-end integration demo is available [here](https://github.com/killbi
 | 6.x.y          | 0.20.z             | [2015-02-18](https://stripe.com/docs/upgrades#2015-02-18) |
 | 7.0.y          | 0.22.z             | [2019-12-03](https://stripe.com/docs/upgrades#2019-12-03) |
 | 7.1.y          | 0.22.z             | [2019-12-03](https://stripe.com/docs/upgrades#2019-12-03) |
+| 7.2.y          | 0.22.z             | [2020-08-27](https://stripe.com/docs/upgrades#2020-08-27) |
 
 We've upgraded numerous dependencies in 7.1.x (required for Java 11 support).
 

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <dependency>
             <groupId>com.stripe</groupId>
             <artifactId>stripe-java</artifactId>
-            <version>17.4.0</version>
+            <version>20.33.0</version>
         </dependency>
         <dependency>
             <groupId>io.airlift</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     </parent>
     <groupId>org.kill-bill.billing.plugin.java</groupId>
     <artifactId>stripe-plugin</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>7.2.0-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <name>Kill Bill Stripe plugin</name>
     <description>Kill Bill Stripe plugin</description>

--- a/src/main/java/org/killbill/billing/plugin/stripe/StripeActivator.java
+++ b/src/main/java/org/killbill/billing/plugin/stripe/StripeActivator.java
@@ -61,7 +61,7 @@ public class StripeActivator extends KillbillActivatorBase {
         registerHealthcheck(context, stripeHealthcheck);
 
         // Register the payment plugin
-        Stripe.setAppInfo("Kill Bill", "7.1.0", "https://killbill.io");
+        Stripe.setAppInfo("Kill Bill", "7.2.0", "https://killbill.io");
         final StripePaymentPluginApi pluginApi = new StripePaymentPluginApi(stripeConfigPropertiesConfigurationHandler,
                                                                             killbillAPI,
                                                                             configProperties,

--- a/src/main/java/org/killbill/billing/plugin/stripe/StripePaymentPluginApi.java
+++ b/src/main/java/org/killbill/billing/plugin/stripe/StripePaymentPluginApi.java
@@ -77,6 +77,7 @@ import com.stripe.model.HasId;
 import com.stripe.model.PaymentIntent;
 import com.stripe.model.PaymentMethod;
 import com.stripe.model.PaymentSource;
+import com.stripe.model.PaymentSourceCollection;
 import com.stripe.model.Refund;
 import com.stripe.model.Source;
 import com.stripe.model.Token;
@@ -424,8 +425,11 @@ public class StripePaymentPluginApi extends PluginPaymentPluginApi<StripeRespons
             syncPaymentMethods(kbAccountId, stripePaymentMethods, existingPaymentMethodByStripeId, stripeObjectsTreated, context);
 
             // Then go through the sources
-            final Iterable<? extends HasId> stripeSources = Customer.retrieve(stripeCustomerId, requestOptions).getSources().autoPagingIterable();
-            syncPaymentMethods(kbAccountId, stripeSources, existingPaymentMethodByStripeId, stripeObjectsTreated, context);
+            final PaymentSourceCollection psc = Customer.retrieve(stripeCustomerId, requestOptions).getSources();
+            if (psc != null) {
+                final Iterable<? extends HasId> stripeSources = psc.autoPagingIterable();
+                syncPaymentMethods(kbAccountId, stripeSources, existingPaymentMethodByStripeId, stripeObjectsTreated, context);
+            }
         } catch (final StripeException e) {
             throw new PaymentPluginApiException("Error connecting to Stripe", e);
         } catch (final PaymentApiException e) {

--- a/src/main/java/org/killbill/billing/plugin/stripe/StripePaymentPluginApi.java
+++ b/src/main/java/org/killbill/billing/plugin/stripe/StripePaymentPluginApi.java
@@ -764,7 +764,7 @@ public class StripePaymentPluginApi extends PluginPaymentPluginApi<StripeRespons
 
                                                  final ImmutableList.Builder<String> paymentMethodTypesBuilder = ImmutableList.builder();
                                                  paymentMethodTypesBuilder.add("card");
-                                                 if (transactionType == TransactionType.PURCHASE) {
+                                                 if (transactionType == TransactionType.PURCHASE && currency == Currency.USD) {
                                                      // See https://groups.google.com/forum/?#!msg/killbilling-users/li3RNs-YmIA/oaUrBElMFQAJ
                                                      paymentMethodTypesBuilder.add("ach_debit");
                                                  }

--- a/src/main/java/org/killbill/billing/plugin/stripe/StripePluginProperties.java
+++ b/src/main/java/org/killbill/billing/plugin/stripe/StripePluginProperties.java
@@ -225,7 +225,7 @@ public abstract class StripePluginProperties {
         additionalDataMap.put("cancel_url", session.getCancelUrl());
         additionalDataMap.put("client_reference_id", session.getClientReferenceId());
         additionalDataMap.put("customer_id", session.getCustomer());
-        additionalDataMap.put("display_items", session.getDisplayItems());
+        additionalDataMap.put("line_items", session.getLineItems());
         additionalDataMap.put("id", session.getId());
         additionalDataMap.put("livemode", session.getLivemode());
         additionalDataMap.put("locale", session.getLocale());

--- a/src/test/java/org/killbill/billing/plugin/stripe/TestStripePaymentPluginApi.java
+++ b/src/test/java/org/killbill/billing/plugin/stripe/TestStripePaymentPluginApi.java
@@ -780,13 +780,17 @@ public class TestStripePaymentPluginApi extends TestBase {
         // so I reverse-engineered the call that stripe.js makes...
         String bankAccount = null;
         try {
-            bankAccount = new StripeJsClient().createBankAccount();
+            bankAccount = new StripeJsClient().createBankAccount(stripeConfigPropertiesConfigurationHandler.getConfigurable(super.context.getTenantId()).getPublicKey());
         } catch (Exception e) {
             fail(e.getMessage());
         }
 
         Map<String, Object> customerParams = new HashMap<String, Object>();
         customerParams.put("source", bankAccount);
+
+        // ensure that the sources are included in the response
+        customerParams.put("expand", ImmutableList.of("sources"));
+
         // Add also a card on the account, to verify we support multiple payment method types per account
         customerParams.put("payment_method", "pm_card_visa");
         final Customer customer = Customer.create(customerParams, options);
@@ -822,14 +826,14 @@ public class TestStripePaymentPluginApi extends TestBase {
             super("https://api.stripe.com/v1/tokens", null, null, null, null, false, 60000, 60000);
         }
 
-        public String createBankAccount() throws Exception {
+        public String createBankAccount(String stripePublishableKey) throws Exception {
             final String accountNumber = "000123456789";
             final String country = "US";
             final String currency = "usd";
             final String routingNumber = "110000000";
             final String name = "Jenny+Rosen";
             final String type = "individual";
-            final String stripePublishableKey = "pk_test_xueTzlxxkKSa5Q47NrnLPcle";
+
             final String body = "bank_account[account_number]=" + accountNumber + "&bank_account[country]=" + country + "&bank_account[currency]=" + currency + "&bank_account[routing_number]=" + routingNumber + "&bank_account[account_holder_name]=" + name + "&bank_account[account_holder_type]=" + type + "&key=" + stripePublishableKey;
 
             final BoundRequestBuilder builder = getBuilderWithHeaderAndQuery(POST, url, ImmutableMap.<String, String>of(), ImmutableMap.<String, String>of()).setBody(body);

--- a/src/test/java/org/killbill/billing/plugin/stripe/TestStripePaymentPluginApi.java
+++ b/src/test/java/org/killbill/billing/plugin/stripe/TestStripePaymentPluginApi.java
@@ -605,7 +605,9 @@ public class TestStripePaymentPluginApi extends TestBase {
         assertNotNull(sessionId);
 
         System.out.println("sessionId: " + sessionId);
-        // Set a breakpoint here and open the index.html test file (use card 4242424242424242)
+        // Set a breakpoint here
+        // Modify src/test/resources/index.html to use your Stripe public key ...
+        // ... then open the file in your browser and test with card 4242424242424242
         System.out.flush();
 
         // Still no payment method

--- a/src/test/java/org/killbill/billing/plugin/stripe/TestStripePaymentPluginApi.java
+++ b/src/test/java/org/killbill/billing/plugin/stripe/TestStripePaymentPluginApi.java
@@ -791,9 +791,13 @@ public class TestStripePaymentPluginApi extends TestBase {
         // ensure that the sources are included in the response
         customerParams.put("expand", ImmutableList.of("sources"));
 
-        // Add also a card on the account, to verify we support multiple payment method types per account
-        customerParams.put("payment_method", "pm_card_visa");
         final Customer customer = Customer.create(customerParams, options);
+
+        // Add also a card on the account, to verify we support multiple payment method types per account
+        PaymentMethod paymentMethod = PaymentMethod.retrieve("pm_card_visa", options);
+        Map<String, Object> pmParams = new HashMap<>();
+        pmParams.put("customer", customer.getId());
+        PaymentMethod updatedPaymentMethod = paymentMethod.attach(pmParams, options);
 
         // Verify the bank account
         final Map<String, Object> params = new HashMap<String, Object>();


### PR DESCRIPTION
Upgrade plugin to Stripe API version https://stripe.com/docs/upgrades#2020-08-27.

All tests are successfully running, except of `testSuccessfulBankAccountPurchase` which was already broken.

I am not sure how you are defining the version number of this plugin. So what's currently missing is an update of README.md to reflect the updated API version. Should this be a new row and plugin version 7.2.y or will it remain at 7.1.y?