### PR TITLE
Add support for SEPA direct debit payment method

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,11 +81,15 @@ curl -v \
      -H "X-Killbill-Comment: demo" \
      "http://127.0.0.1:8080/plugins/killbill-stripe/checkout?kbAccountId=<KB_ACCOUNT_ID>"
 ```
+
+The default is to only allow credit cards. If you want to enable sepa direct debit payments, you need to include the `paymentMethodTypes` option, i.e. change the URL of your POST request
+to `http://127.0.0.1:8080/plugins/killbill-stripe/checkout?kbAccountId=<KB_ACCOUNT_ID>&paymentMethodTypes=card&paymentMethodTypes=sepa_debit`.
+
 3. Redirect the user to the Stripe checkout page. The `sessionId` is returned as part of the `formFields` (`id` key):
 ```javascript
 stripe.redirectToCheckout({ sessionId: 'cs_test_XXX' });
 ```
-4. After entering the credit card, a $1 authorization will be triggered. Call `addPaymentMethod` to create the Stripe payment method and pass the `sessionId` in the plugin properties. This will void the authorization (if successful) and store the payment method in Kill Bill:
+4. After entering the credit card or bank account details, the payment method will be available in Stripe. Call `addPaymentMethod` to store the payment method in Kill Bill:
 ```bash
 curl -v \
      -X POST \
@@ -158,6 +162,15 @@ curl -v \
      -H "X-Killbill-Comment: demo" \
      "http://127.0.0.1:8080/1.0/kb/accounts/<ACCOUNT_ID>/paymentMethods/refresh"
 ```
+## Development
+
+For testing you need to add your Stripe public and private key to `src/test/resources/stripe.properties`:
+
+```
+org.killbill.billing.plugin.stripe.apiKey=sk_test_XXX
+org.killbill.billing.plugin.stripe.publicKey=pk_test_XXX
+```
+
 ## About
 
 Kill Bill is the leading Open-Source Subscription Billing & Payments Platform. For more information about the project, go to https://killbill.io/.

--- a/src/main/java/org/killbill/billing/plugin/stripe/StripeCheckoutServlet.java
+++ b/src/main/java/org/killbill/billing/plugin/stripe/StripeCheckoutServlet.java
@@ -17,6 +17,7 @@
 
 package org.killbill.billing.plugin.stripe;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -62,18 +63,16 @@ public class StripeCheckoutServlet extends PluginHealthcheck {
     public Result createSession(@Named("kbAccountId") final UUID kbAccountId,
                                 @Named("successUrl") final Optional<String> successUrl,
                                 @Named("cancelUrl") final Optional<String> cancelUrl,
-                                @Named("lineItemName") final Optional<String> lineItemName,
                                 @Named("kbInvoiceId") final Optional<String> kbInvoiceId,
-                                @Named("lineItemAmount") final Optional<Integer> lineItemAmount,
+                                @Named("paymentMethodTypes") final Optional<List<String>> paymentMethodTypes,
                                 @Local @Named("killbill_tenant") final Tenant tenant) throws JsonProcessingException, PaymentPluginApiException {
         final CallContext context = new PluginCallContext(StripeActivator.PLUGIN_NAME, clock.getClock().getUTCNow(), kbAccountId, tenant.getId());
         final ImmutableList<PluginProperty> customFields = ImmutableList.of(
                 new PluginProperty("kb_account_id", kbAccountId.toString(), false),
                 new PluginProperty("kb_invoice_id", kbInvoiceId.orElse(null), false),
-                new PluginProperty("success_url", successUrl.orElse("https://example.com/success"), false),
+                new PluginProperty("success_url", successUrl.orElse("https://example.com/success?sessionId={CHECKOUT_SESSION_ID}"), false),
                 new PluginProperty("cancel_url", cancelUrl.orElse("https://example.com/cancel"), false),
-                new PluginProperty("line_item_name", lineItemName.orElse("Authorization charge"), false),
-                new PluginProperty("line_item_amount", lineItemAmount.orElse(100), false));
+                new PluginProperty("payment_method_types", paymentMethodTypes.orElse(null), false));
         final HostedPaymentPageFormDescriptor hostedPaymentPageFormDescriptor = stripePaymentPluginApi.buildFormDescriptor(kbAccountId,
                                                                                                                            customFields,
                                                                                                                            ImmutableList.of(),

--- a/src/main/java/org/killbill/billing/plugin/stripe/StripePluginProperties.java
+++ b/src/main/java/org/killbill/billing/plugin/stripe/StripePluginProperties.java
@@ -28,6 +28,8 @@ import com.stripe.model.PaymentIntent;
 import com.stripe.model.PaymentMethod;
 import com.stripe.model.PaymentMethod.Card;
 import com.stripe.model.PaymentSource;
+import com.stripe.model.SetupIntent;
+import com.stripe.model.SetupIntent.PaymentMethodOptions;
 import com.stripe.model.Source;
 import com.stripe.model.Source.AchDebit;
 import com.stripe.model.Token;
@@ -77,6 +79,16 @@ public abstract class StripePluginProperties {
                 additionalDataMap.put("ach_debit_last4", achDebit.getLast4());
                 additionalDataMap.put("ach_debit_routing_number", achDebit.getRoutingNumber());
                 additionalDataMap.put("ach_debit_type", achDebit.getType());
+            }
+            final Source.SepaDebit sepaDebit = stripeSource.getSepaDebit();
+            if (sepaDebit != null) {
+                additionalDataMap.put("sepa_debit_bank_code", sepaDebit.getBankCode());
+                additionalDataMap.put("sepa_debit_branch_code", sepaDebit.getBranchCode());
+                additionalDataMap.put("sepa_debit_country", sepaDebit.getCountry());
+                additionalDataMap.put("sepa_debit_fingerprint", sepaDebit.getFingerprint());
+                additionalDataMap.put("sepa_debit_last4", sepaDebit.getLast4());
+                additionalDataMap.put("sepa_debit_mandate_reference", sepaDebit.getMandateReference());
+                additionalDataMap.put("sepa_debit_mandate_url", sepaDebit.getMandateUrl());
             }
             additionalDataMap.put("created", stripeSource.getCreated());
             additionalDataMap.put("customer_id", stripeSource.getCustomer());
@@ -143,6 +155,15 @@ public abstract class StripePluginProperties {
                 additionalDataMap.put("card_wallet_type", card.getWallet().getType());
             }
         }
+        final PaymentMethod.SepaDebit sepaDebit = stripePaymentMethod.getSepaDebit();
+        if (sepaDebit != null) {
+            additionalDataMap.put("sepa_debit_bank_code", sepaDebit.getBankCode());
+            additionalDataMap.put("sepa_debit_branch_code", sepaDebit.getBranchCode());
+            additionalDataMap.put("sepa_debit_country", sepaDebit.getCountry());
+            additionalDataMap.put("sepa_debit_fingerprint", sepaDebit.getFingerprint());
+            additionalDataMap.put("sepa_debit_last4", sepaDebit.getLast4());
+        }
+
         additionalDataMap.put("created", stripePaymentMethod.getCreated());
         additionalDataMap.put("customer_id", stripePaymentMethod.getCustomer());
         additionalDataMap.put("id", stripePaymentMethod.getId());
@@ -218,6 +239,41 @@ public abstract class StripePluginProperties {
         return additionalDataMap;
     }
 
+    public static Map<String, Object> toAdditionalDataMap(final SetupIntent stripeSetupIntent) {
+        final Map<String, Object> additionalDataMap = new HashMap<String, Object>();
+
+        additionalDataMap.put("application", stripeSetupIntent.getApplication());
+        additionalDataMap.put("cancellation_reason", stripeSetupIntent.getCancellationReason());
+        additionalDataMap.put("created", stripeSetupIntent.getCreated());
+        additionalDataMap.put("customer_id", stripeSetupIntent.getCustomer());
+        additionalDataMap.put("description", stripeSetupIntent.getDescription());
+        additionalDataMap.put("id", stripeSetupIntent.getId());
+        additionalDataMap.put("last_setup_error", stripeSetupIntent.getLastSetupError());
+        additionalDataMap.put("latest_attempt", stripeSetupIntent.getLatestAttempt());
+        additionalDataMap.put("livemode", stripeSetupIntent.getLivemode());
+        additionalDataMap.put("mandate", stripeSetupIntent.getMandate());
+        additionalDataMap.put("metadata", stripeSetupIntent.getMetadata());
+        additionalDataMap.put("next_action", stripeSetupIntent.getNextAction());
+        additionalDataMap.put("object", stripeSetupIntent.getObject());
+        additionalDataMap.put("on_behalf_of", stripeSetupIntent.getOnBehalfOf());
+        additionalDataMap.put("payment_method_id", stripeSetupIntent.getPaymentMethod());
+        final PaymentMethodOptions paymentMethodOptions = stripeSetupIntent.getPaymentMethodOptions();
+        if (paymentMethodOptions != null ) {
+            final SetupIntent.PaymentMethodOptions.Card card = paymentMethodOptions.getCard();
+            if (card != null) {
+                additionalDataMap.put("payment_method_options_card_request_three_d_secure", card.getRequestThreeDSecure());
+            }
+            // paymentMethodOptions also contains "sepa_debit" which contains "mandate_options" that currently has
+            // no properties, so it is ignored here (https://stripe.com/docs/api/setup_intents/object)
+        }
+        additionalDataMap.put("payment_method_types", stripeSetupIntent.getPaymentMethodTypes());
+        additionalDataMap.put("single_use_mandate_id", stripeSetupIntent.getSingleUseMandate());
+        additionalDataMap.put("status", stripeSetupIntent.getStatus());
+        additionalDataMap.put("usage", stripeSetupIntent.getUsage());
+
+        return additionalDataMap;
+    }
+
     public static Map<String, Object> toAdditionalDataMap(final Session session, @Nullable final String pk) {
         final Map<String, Object> additionalDataMap = new HashMap<String, Object>();
 
@@ -232,6 +288,7 @@ public abstract class StripePluginProperties {
         additionalDataMap.put("object", session.getObject());
         additionalDataMap.put("payment_intent_id", session.getPaymentIntent());
         additionalDataMap.put("payment_method_types", session.getPaymentMethodTypes());
+        additionalDataMap.put("setup_intent_id", session.getSetupIntent());
         additionalDataMap.put("subscription_id", session.getSubscription());
         additionalDataMap.put("success_url", session.getSuccessUrl());
         if (pk != null) {

--- a/src/test/java/org/killbill/billing/plugin/stripe/TestBase.java
+++ b/src/test/java/org/killbill/billing/plugin/stripe/TestBase.java
@@ -21,6 +21,8 @@ import java.util.List;
 import java.util.Properties;
 import java.util.UUID;
 
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.killbill.billing.ObjectType;
 import org.killbill.billing.account.api.Account;
 import org.killbill.billing.catalog.api.Currency;
@@ -57,6 +59,38 @@ public class TestBase {
     protected StripeConfigPropertiesConfigurationHandler stripeConfigPropertiesConfigurationHandler;
     protected StripeDao dao;
 
+    private static Account buildAccount(final Currency currency, final String country) {
+        return buildAccount(currency, UUID.randomUUID().toString(), UUID.randomUUID().toString(), UUID.randomUUID().toString(), UUID.randomUUID().toString(), UUID.randomUUID().toString().substring(0, 16), country);
+    }
+
+    // Currently needed as TestUtils.buildAccount does not create a valid e-mail address
+    private static Account buildAccount(final Currency currency, final String address1, final String address2, final String city, final String stateOrProvince, final String postalCode, final String country) {
+        Account account = (Account)Mockito.mock(Account.class);
+        Mockito.when(account.getId()).thenReturn(UUID.randomUUID());
+        Mockito.when(account.getExternalKey()).thenReturn(UUID.randomUUID().toString());
+        Mockito.when(account.getName()).thenReturn(UUID.randomUUID().toString());
+        Mockito.when(account.getFirstNameLength()).thenReturn(4);
+        Mockito.when(account.getEmail()).thenReturn(UUID.randomUUID().toString() + "@example.com");
+        Mockito.when(account.getBillCycleDayLocal()).thenReturn(2);
+        Mockito.when(account.getCurrency()).thenReturn(currency);
+        Mockito.when(account.getPaymentMethodId()).thenReturn(UUID.randomUUID());
+        Mockito.when(account.getTimeZone()).thenReturn(DateTimeZone.getDefault());
+        Mockito.when(account.getLocale()).thenReturn("en-US");
+        Mockito.when(account.getAddress1()).thenReturn(address1);
+        Mockito.when(account.getAddress2()).thenReturn(address2);
+        Mockito.when(account.getCompanyName()).thenReturn(UUID.randomUUID().toString());
+        Mockito.when(account.getCity()).thenReturn(city);
+        Mockito.when(account.getStateOrProvince()).thenReturn(stateOrProvince);
+        Mockito.when(account.getPostalCode()).thenReturn(postalCode);
+        Mockito.when(account.getCountry()).thenReturn(country);
+        Mockito.when(account.getPhone()).thenReturn(UUID.randomUUID().toString().substring(0, 25));
+        Mockito.when(account.isMigrated()).thenReturn(true);
+        Mockito.when(account.getCreatedDate()).thenReturn(new DateTime(2016, 1, 22, 10, 56, 47, DateTimeZone.UTC));
+        Mockito.when(account.getUpdatedDate()).thenReturn(new DateTime(2016, 1, 22, 10, 56, 48, DateTimeZone.UTC));
+        return account;
+    }
+
+
     @BeforeMethod(groups = {"slow", "integration"})
     public void setUp() throws Exception {
         EmbeddedDbHelper.instance().resetDB();
@@ -67,7 +101,7 @@ public class TestBase {
         context = Mockito.mock(CallContext.class);
         Mockito.when(context.getTenantId()).thenReturn(UUID.randomUUID());
 
-        account = TestUtils.buildAccount(DEFAULT_CURRENCY, DEFAULT_COUNTRY);
+        account = buildAccount(DEFAULT_CURRENCY, DEFAULT_COUNTRY);
         killbillApi = TestUtils.buildOSGIKillbillAPI(account);
         customFieldUserApi = Mockito.mock(CustomFieldUserApi.class);
         Mockito.when(killbillApi.getCustomFieldUserApi()).thenReturn(customFieldUserApi);

--- a/src/test/java/org/killbill/billing/plugin/stripe/TestBase.java
+++ b/src/test/java/org/killbill/billing/plugin/stripe/TestBase.java
@@ -59,38 +59,6 @@ public class TestBase {
     protected StripeConfigPropertiesConfigurationHandler stripeConfigPropertiesConfigurationHandler;
     protected StripeDao dao;
 
-    private static Account buildAccount(final Currency currency, final String country) {
-        return buildAccount(currency, UUID.randomUUID().toString(), UUID.randomUUID().toString(), UUID.randomUUID().toString(), UUID.randomUUID().toString(), UUID.randomUUID().toString().substring(0, 16), country);
-    }
-
-    // Currently needed as TestUtils.buildAccount does not create a valid e-mail address
-    private static Account buildAccount(final Currency currency, final String address1, final String address2, final String city, final String stateOrProvince, final String postalCode, final String country) {
-        Account account = (Account)Mockito.mock(Account.class);
-        Mockito.when(account.getId()).thenReturn(UUID.randomUUID());
-        Mockito.when(account.getExternalKey()).thenReturn(UUID.randomUUID().toString());
-        Mockito.when(account.getName()).thenReturn(UUID.randomUUID().toString());
-        Mockito.when(account.getFirstNameLength()).thenReturn(4);
-        Mockito.when(account.getEmail()).thenReturn(UUID.randomUUID().toString() + "@example.com");
-        Mockito.when(account.getBillCycleDayLocal()).thenReturn(2);
-        Mockito.when(account.getCurrency()).thenReturn(currency);
-        Mockito.when(account.getPaymentMethodId()).thenReturn(UUID.randomUUID());
-        Mockito.when(account.getTimeZone()).thenReturn(DateTimeZone.getDefault());
-        Mockito.when(account.getLocale()).thenReturn("en-US");
-        Mockito.when(account.getAddress1()).thenReturn(address1);
-        Mockito.when(account.getAddress2()).thenReturn(address2);
-        Mockito.when(account.getCompanyName()).thenReturn(UUID.randomUUID().toString());
-        Mockito.when(account.getCity()).thenReturn(city);
-        Mockito.when(account.getStateOrProvince()).thenReturn(stateOrProvince);
-        Mockito.when(account.getPostalCode()).thenReturn(postalCode);
-        Mockito.when(account.getCountry()).thenReturn(country);
-        Mockito.when(account.getPhone()).thenReturn(UUID.randomUUID().toString().substring(0, 25));
-        Mockito.when(account.isMigrated()).thenReturn(true);
-        Mockito.when(account.getCreatedDate()).thenReturn(new DateTime(2016, 1, 22, 10, 56, 47, DateTimeZone.UTC));
-        Mockito.when(account.getUpdatedDate()).thenReturn(new DateTime(2016, 1, 22, 10, 56, 48, DateTimeZone.UTC));
-        return account;
-    }
-
-
     @BeforeMethod(groups = {"slow", "integration"})
     public void setUp() throws Exception {
         EmbeddedDbHelper.instance().resetDB();
@@ -101,7 +69,8 @@ public class TestBase {
         context = Mockito.mock(CallContext.class);
         Mockito.when(context.getTenantId()).thenReturn(UUID.randomUUID());
 
-        account = buildAccount(DEFAULT_CURRENCY, DEFAULT_COUNTRY);
+        account = TestUtils.buildAccount(DEFAULT_CURRENCY, DEFAULT_COUNTRY);
+        Mockito.when(account.getEmail()).thenReturn(UUID.randomUUID().toString() + "@example.com");
         killbillApi = TestUtils.buildOSGIKillbillAPI(account);
         customFieldUserApi = Mockito.mock(CustomFieldUserApi.class);
         Mockito.when(killbillApi.getCustomFieldUserApi()).thenReturn(customFieldUserApi);

--- a/src/test/java/org/killbill/billing/plugin/stripe/TestStripePaymentPluginApi.java
+++ b/src/test/java/org/killbill/billing/plugin/stripe/TestStripePaymentPluginApi.java
@@ -597,7 +597,7 @@ public class TestStripePaymentPluginApi extends TestBase {
         }
     }
 
-    @Test(groups = "integration", enabled = true, description = "Manual test")
+    @Test(groups = "integration", enabled = false, description = "Manual test")
     public void testHPP() throws PaymentPluginApiException, StripeException, PaymentApiException {
         final UUID kbAccountId = account.getId();
         final List<String> paymentMethodTypes = new ArrayList<String>();

--- a/src/test/java/org/killbill/billing/plugin/stripe/TestStripePaymentPluginApi.java
+++ b/src/test/java/org/killbill/billing/plugin/stripe/TestStripePaymentPluginApi.java
@@ -793,7 +793,6 @@ public class TestStripePaymentPluginApi extends TestBase {
         // so I reverse-engineered the call that stripe.js makes...
         String bankAccount = null;
         try {
-            System.out.println(super.context.getTenantId());
             // make sure to have your public key included in src/test/resources/stripe.properties (see README.md)
             bankAccount = new StripeJsClient().createBankAccount(stripeConfigPropertiesConfigurationHandler.getConfigurable(super.context.getTenantId()).getPublicKey());
         } catch (Exception e) {

--- a/src/test/java/org/killbill/billing/plugin/stripe/TestStripePaymentPluginApi.java
+++ b/src/test/java/org/killbill/billing/plugin/stripe/TestStripePaymentPluginApi.java
@@ -28,6 +28,7 @@ import java.util.UUID;
 import org.asynchttpclient.BoundRequestBuilder;
 import org.joda.time.Period;
 import org.killbill.billing.ObjectType;
+import org.killbill.billing.catalog.api.Currency;
 import org.killbill.billing.payment.api.Payment;
 import org.killbill.billing.payment.api.PaymentApiException;
 import org.killbill.billing.payment.api.PaymentMethodPlugin;
@@ -57,7 +58,9 @@ import com.stripe.model.BankAccount;
 import com.stripe.model.Customer;
 import com.stripe.model.PaymentIntent;
 import com.stripe.model.PaymentMethod;
+import com.stripe.model.PaymentMethod.Card;
 import com.stripe.model.PaymentSource;
+import com.stripe.model.SetupIntent;
 import com.stripe.model.Token;
 import com.stripe.net.RequestOptions;
 
@@ -81,7 +84,7 @@ public class TestStripePaymentPluginApi extends TestBase {
         final Map<String, Object> card = new HashMap<>();
         card.put("number", "4242424242424242");
         card.put("exp_month", 1);
-        card.put("exp_year", 2021);
+        card.put("exp_year", 2030);
         card.put("cvc", "314");
         final Map<String, Object> params = new HashMap<>();
         params.put("card", card);
@@ -133,7 +136,7 @@ public class TestStripePaymentPluginApi extends TestBase {
         final Map<String, Object> card = new HashMap<>();
         card.put("number", "4242424242424242");
         card.put("exp_month", 1);
-        card.put("exp_year", 2021);
+        card.put("exp_year", 2030);
         card.put("cvc", "314");
         final Map<String, Object> params = new HashMap<>();
         params.put("card", card);
@@ -594,11 +597,15 @@ public class TestStripePaymentPluginApi extends TestBase {
         }
     }
 
-    @Test(groups = "integration", enabled = false, description = "Manual test")
+    @Test(groups = "integration", enabled = true, description = "Manual test")
     public void testHPP() throws PaymentPluginApiException, StripeException, PaymentApiException {
         final UUID kbAccountId = account.getId();
+        final List<String> paymentMethodTypes = new ArrayList<String>();
+        paymentMethodTypes.add("card");
+        paymentMethodTypes.add("sepa_debit");
+        final ImmutableList<PluginProperty> customFields = ImmutableList.of(new PluginProperty("payment_method_types", paymentMethodTypes, false));
         final HostedPaymentPageFormDescriptor hostedPaymentPageFormDescriptor = stripePaymentPluginApi.buildFormDescriptor(kbAccountId,
-                                                                                                                           ImmutableList.of(),
+                                                                                                                           customFields,
                                                                                                                            ImmutableList.of(),
                                                                                                                            context);
         final String sessionId = PluginProperties.findPluginPropertyValue("id", hostedPaymentPageFormDescriptor.getFormFields());
@@ -607,7 +614,7 @@ public class TestStripePaymentPluginApi extends TestBase {
         System.out.println("sessionId: " + sessionId);
         // Set a breakpoint here
         // Modify src/test/resources/index.html to use your Stripe public key ...
-        // ... then open the file in your browser and test with card 4242424242424242
+        // ... then open the file in your browser and test either with card 4242424242424242 or with sepa debit DE89370400440532013000
         System.out.flush();
 
         // Still no payment method
@@ -631,16 +638,19 @@ public class TestStripePaymentPluginApi extends TestBase {
         // Verify refresh is a no-op. This will also verify that the custom field was created
         assertEquals(stripePaymentPluginApi.getPaymentMethods(kbAccountId, true, ImmutableList.<PluginProperty>of(), context), paymentMethodsNoRefresh);
 
-        // Verify customer has no payment (voided)
-        final String paymentIntentId = PluginProperties.findPluginPropertyValue("payment_intent_id", hostedPaymentPageFormDescriptor.getFormFields());
-        assertEquals(PaymentIntent.retrieve(paymentIntentId, stripePaymentPluginApi.buildRequestOptions(context)).getStatus(), "canceled");
+        // Verify successful "setup intent"
+        final String setupIntentId = PluginProperties.findPluginPropertyValue("setup_intent_id", hostedPaymentPageFormDescriptor.getFormFields());
+        assertEquals(SetupIntent.retrieve(setupIntentId, stripePaymentPluginApi.buildRequestOptions(context)).getStatus(), "succeeded");
 
-        // Verify we can charge the card
+        // Verify we can charge the payment method
         paymentMethodPlugin = stripePaymentPluginApi.getPaymentMethodDetail(kbAccountId,
                                                                             paymentMethodsNoRefresh.get(0).getPaymentMethodId(),
                                                                             ImmutableList.of(),
                                                                             context);
-        final Payment payment = TestUtils.buildPayment(account.getId(), account.getPaymentMethodId(), account.getCurrency(), killbillApi);
+        final PluginProperty pmType = paymentMethodPlugin.getProperties().stream().filter(prop -> "type".equals(prop.getKey())).findFirst().orElse(null);
+        final Boolean isSepaDebit = pmType != null && "sepa_debit".equals(pmType.getValue());
+        // sepa debit is only available for EUR so for testing we make sure to use EUR in that case
+        final Payment payment = TestUtils.buildPayment(account.getId(), account.getPaymentMethodId(), isSepaDebit ? Currency.EUR : account.getCurrency(), killbillApi);
         final PaymentTransaction purchaseTransaction = TestUtils.buildPaymentTransaction(payment, TransactionType.AUTHORIZE, BigDecimal.TEN, payment.getCurrency());
         final PaymentTransactionInfoPlugin purchaseInfoPlugin = stripePaymentPluginApi.purchasePayment(account.getId(),
                                                                                                        payment.getId(),
@@ -650,8 +660,11 @@ public class TestStripePaymentPluginApi extends TestBase {
                                                                                                        purchaseTransaction.getCurrency(),
                                                                                                        ImmutableList.of(),
                                                                                                        context);
+        // sepa debit transactions will be returned as "PENDING" (i.e. status='processing') by Stripe instead of "PROCESSED" (i.e. status='succeeded')
+        final PaymentPluginStatus targetStatus = isSepaDebit ? PaymentPluginStatus.PENDING : PaymentPluginStatus.PROCESSED;
+
         TestUtils.updatePaymentTransaction(purchaseTransaction, purchaseInfoPlugin);
-        verifyPaymentTransactionInfoPlugin(payment, purchaseTransaction, purchaseInfoPlugin, PaymentPluginStatus.PROCESSED);
+        verifyPaymentTransactionInfoPlugin(payment, purchaseTransaction, purchaseInfoPlugin, targetStatus);
     }
 
     private void verifyPaymentTransactionInfoPlugin(final Payment payment,
@@ -704,7 +717,7 @@ public class TestStripePaymentPluginApi extends TestBase {
     }
 
     private Customer createStripeCustomerWithCreditCard(final UUID kbAccountId) throws StripeException {
-        // Create new customer with VISA card
+        // Create new customer with VISA card, see: https://stripe.com/docs/testing
         Map<String, Object> customerParams = new HashMap<String, Object>();
         customerParams.put("payment_method", "pm_card_visa");
         final Customer customer = Customer.create(customerParams, stripePaymentPluginApi.buildRequestOptions(context));
@@ -736,7 +749,7 @@ public class TestStripePaymentPluginApi extends TestBase {
     }
 
     private Customer createStripeCustomerWith3DSCreditCard(final UUID kbAccountId) throws StripeException {
-        // Create new customer with VISA card
+        // Create new customer with VISA card, see: https://stripe.com/docs/testing
         Map<String, Object> customerParams = new HashMap<String, Object>();
         customerParams.put("payment_method", "pm_card_threeDSecure2Required");
         final Customer customer = Customer.create(customerParams, stripePaymentPluginApi.buildRequestOptions(context));
@@ -780,6 +793,8 @@ public class TestStripePaymentPluginApi extends TestBase {
         // so I reverse-engineered the call that stripe.js makes...
         String bankAccount = null;
         try {
+            System.out.println(super.context.getTenantId());
+            // make sure to have your public key included in src/test/resources/stripe.properties (see README.md)
             bankAccount = new StripeJsClient().createBankAccount(stripeConfigPropertiesConfigurationHandler.getConfigurable(super.context.getTenantId()).getPublicKey());
         } catch (Exception e) {
             fail(e.getMessage());


### PR DESCRIPTION
This PR adds support for SEPA direct debit. 

The previous flow for credit cards which uses Stripe's Payment Intents API (1$ card auth which is later voided) does not work with SEPA direct debit, as SEPA direct debit can only be used with an automatic capture. To keep the overall amount of code as low as possible the credit card flow was also adapted such that there is only one flow for both payment methods. Instead of using the Payment Intents API the plugin now uses Setup Intents, i.e. the payment method is only setup for later payments.

When this PR is in a state to be merged, we need to change the version number of the plugin.