### PR TITLE
Allow stripe to collect billing address

### DIFF
--- a/src/main/java/org/killbill/billing/plugin/stripe/StripeCheckoutServlet.java
+++ b/src/main/java/org/killbill/billing/plugin/stripe/StripeCheckoutServlet.java
@@ -65,14 +65,16 @@ public class StripeCheckoutServlet extends PluginHealthcheck {
                                 @Named("cancelUrl") final Optional<String> cancelUrl,
                                 @Named("kbInvoiceId") final Optional<String> kbInvoiceId,
                                 @Named("paymentMethodTypes") final Optional<List<String>> paymentMethodTypes,
-                                @Local @Named("killbill_tenant") final Tenant tenant) throws JsonProcessingException, PaymentPluginApiException {
+                                @Local @Named("killbill_tenant") final Tenant tenant,
+                                @Named("billingAddressCollection") final Optional<String> billingAddressCollection) throws JsonProcessingException, PaymentPluginApiException {
         final CallContext context = new PluginCallContext(StripeActivator.PLUGIN_NAME, clock.getClock().getUTCNow(), kbAccountId, tenant.getId());
         final ImmutableList<PluginProperty> customFields = ImmutableList.of(
                 new PluginProperty("kb_account_id", kbAccountId.toString(), false),
                 new PluginProperty("kb_invoice_id", kbInvoiceId.orElse(null), false),
                 new PluginProperty("success_url", successUrl.orElse("https://example.com/success?sessionId={CHECKOUT_SESSION_ID}"), false),
                 new PluginProperty("cancel_url", cancelUrl.orElse("https://example.com/cancel"), false),
-                new PluginProperty("payment_method_types", paymentMethodTypes.orElse(null), false));
+                new PluginProperty("payment_method_types", paymentMethodTypes.orElse(null), false),
+                new PluginProperty("billing_address_collection", billingAddressCollection.orElse("auto"), false));
         final HostedPaymentPageFormDescriptor hostedPaymentPageFormDescriptor = stripePaymentPluginApi.buildFormDescriptor(kbAccountId,
                                                                                                                            customFields,
                                                                                                                            ImmutableList.of(),

--- a/src/main/java/org/killbill/billing/plugin/stripe/StripePaymentPluginApi.java
+++ b/src/main/java/org/killbill/billing/plugin/stripe/StripePaymentPluginApi.java
@@ -701,6 +701,7 @@ public class StripePaymentPluginApi extends PluginPaymentPluginApi<StripeRespons
         params.put("mode", "setup");
         params.put("success_url", PluginProperties.getValue("success_url", "https://example.com/success?sessionId={CHECKOUT_SESSION_ID}", customFields));
         params.put("cancel_url", PluginProperties.getValue("cancel_url", "https://example.com/cancel", customFields));
+        params.put("billing_address_collection", PluginProperties.getValue("billing_address_collection", "auto", customFields));
         final StripeConfigProperties stripeConfigProperties = stripeConfigPropertiesConfigurationHandler.getConfigurable(context.getTenantId());
 
         try {


### PR DESCRIPTION
All payments in foreign currencies require the billing address information to be collected, stripe allows to collect billing address collection in the checkout API. Since not everyone wants to save address in their database there are many use cases where this should be handled by stripe. For E.g. while using killbill only as a generic payment gateway. 

I have added the parameter in the checkout API which can be set to allow billing address collection. The flag value is described in the stripe documentation [here](https://stripe.com/docs/api/checkout/sessions/object).