### PR TITLE
Enrich Stripe customer with killbill account information

### DIFF
--- a/src/main/java/org/killbill/billing/plugin/stripe/StripePaymentPluginApi.java
+++ b/src/main/java/org/killbill/billing/plugin/stripe/StripePaymentPluginApi.java
@@ -931,18 +931,6 @@ public class StripePaymentPluginApi extends PluginPaymentPluginApi<StripeRespons
         return stripeCustomerId;
     }
 
-    private String getKbAccountName(final UUID kbAccountId, final CallContext context) {
-        final List<CustomField> customFields = killbillAPI.getAccount(kbAccountId);
-        String stripeCustomerId = null;
-        for (final CustomField customField : customFields) {
-            if (customField.getFieldName().equals("STRIPE_CUSTOMER_ID")) {
-                stripeCustomerId = customField.getFieldValue();
-                break;
-            }
-        }
-        return stripeCustomerId;
-    }
-
     private StripePaymentMethodsRecord getStripePaymentMethodsRecord(@Nullable final UUID kbPaymentMethodId, final TenantContext context) throws PaymentPluginApiException {
         StripePaymentMethodsRecord paymentMethodsRecord = null;
 


### PR DESCRIPTION
The Stripe plugin is setting a one-direction relation using the killbill custom fields to store the Stripe customer ID

This PR wants to add a reverse relation using the killbill account ID into the Stripe customer metadata.

The goal is also to use a Stripe customer name that is user friendly when available in killbill.