### PR TITLE
Enrich Stripe customer with killbill account information

### DIFF
--- a/src/main/java/org/killbill/billing/plugin/stripe/StripePaymentPluginApi.java
+++ b/src/main/java/org/killbill/billing/plugin/stripe/StripePaymentPluginApi.java
@@ -310,8 +310,13 @@ public class StripePaymentPluginApi extends PluginPaymentPluginApi<StripeRespons
                     final String existingCustomerId = getCustomerIdNoException(kbAccountId, context);
                     final String createStripeCustomerProperty = PluginProperties.findPluginPropertyValue("createStripeCustomer", allProperties);
                     if (existingCustomerId == null && (createStripeCustomerProperty == null || Boolean.parseBoolean(createStripeCustomerProperty))) {
+                        final Account account = getAccount(kbAccountId, context);
+
                         final Map<String, Object> customerParams = new HashMap<>();
                         customerParams.put("source", paymentMethodIdInStripe);
+                        customerParams.put("metadata", ImmutableMap.of("kbAccountId", kbAccountId,
+                                                                       "kbAccountExternalKey", account.getExternalKey()));
+
                         logger.info("Creating customer in Stripe to be able to re-use the token");
                         final Customer customer = Customer.create(customerParams, requestOptions);
                         // The id to charge now is the default source (e.g. card), not the token


### PR DESCRIPTION
The Stripe plugin is setting a one-direction relation using the killbill custom fields to store the Stripe customer ID

This PR wants to add a reverse relation using the killbill account ID and externalKey into the Stripe customer metadata.

![image](https://user-images.githubusercontent.com/24460646/148410222-21772a4b-972c-47e3-97e6-597db5927f32.png)
