### PR TITLE
Improve the creation of customer based on source instead of token

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,9 +109,11 @@ curl -v \
      "http://127.0.0.1:8080/1.0/kb/accounts/<KB_ACCOUNT_ID>/paymentMethods?pluginProperty=sessionId=cs_test_XXX"
 ```
 
-### Using tokens
+### Using tokens and sources
 
-If you have a [token](https://stripe.com/docs/api/tokens), you can pass it directly to `addPaymentMethod` in the plugin properties:
+If you have a [token](https://stripe.com/docs/api/tokens) or [sources](https://stripe.com/docs/api/sources), you can pass it directly to `addPaymentMethod` in the plugin properties:
+
+##### Token
 
 ```bash
 curl -v \
@@ -128,9 +130,26 @@ curl -v \
      "http://127.0.0.1:8080/1.0/kb/accounts/<KB_ACCOUNT_ID>/paymentMethods?pluginProperty=token=tok_XXX"
 ```
 
+##### Source
+
+```bash
+curl -v \
+     -X POST \
+     -u admin:password \
+     -H "X-Killbill-ApiKey: bob" \
+     -H "X-Killbill-ApiSecret: lazar" \
+     -H "Content-Type: application/json" \
+     -H "Accept: application/json" \
+     -H "X-Killbill-CreatedBy: demo" \
+     -H "X-Killbill-Reason: demo" \
+     -H "X-Killbill-Comment: demo" \
+     -d "{ \"pluginName\": \"killbill-stripe\"}" \
+     "http://127.0.0.1:8080/1.0/kb/accounts/<KB_ACCOUNT_ID>/paymentMethods?pluginProperty=source=src_XXX"
+```
+
 Take a look at [kbcmd](https://github.com/killbill/kbcli/blob/master/docs/kbcmd/kbcmd-walkthrough.md) for a step-by-step walkthrough.
 
-Note: if the token is already attached to a customer in Stripe, make sure to first set the `STRIPE_CUSTOMER_ID` custom field to the account in Kill Bill (see below) before calling `addPaymentMethod` (in this case, the token will be stored as-is and assumed to be re-usable if you intent to do subsequent payments). Otherwise, the plugin assumes it is a one-time token and will automatically create an associated customer in Stripe attached to this token to be able to re-use it (if needed, you can bypass this logic by specifying the `createStripeCustomer=false` plugin property in the `addPaymentMethod` call).
+Note: if the token/source is already attached to a customer in Stripe, make sure to first set the `STRIPE_CUSTOMER_ID` custom field to the account in Kill Bill (see below) before calling `addPaymentMethod` (in this case, the token will be stored as-is and assumed to be re-usable if you intent to do subsequent payments). Otherwise, the plugin assumes it is a one-time token and will automatically create an associated customer in Stripe attached to this token/source to be able to re-use it (if needed, you can bypass this logic by specifying the `createStripeCustomer=false` plugin property in the `addPaymentMethod` call).
 
 ### Other methods
 

--- a/src/main/java/org/killbill/billing/plugin/stripe/StripePaymentPluginApi.java
+++ b/src/main/java/org/killbill/billing/plugin/stripe/StripePaymentPluginApi.java
@@ -312,7 +312,7 @@ public class StripePaymentPluginApi extends PluginPaymentPluginApi<StripeRespons
                 try {
                     final Token stripeToken = Token.retrieve(paymentMethodIdInStripe, requestOptions);
                     additionalDataMap = StripePluginProperties.toAdditionalDataMap(stripeToken);
-                    stripeId = createStripeCustomer(kbAccountId, context, requestOptions, allProperties, paymentMethodIdInStripe, stripeToken.getId());
+                    stripeId = createStripeCustomer(kbAccountId, paymentMethodIdInStripe, stripeToken.getId(), requestOptions, allProperties, context);
                 } catch (final StripeException e) {
                     throw new PaymentPluginApiException("Error calling Stripe while adding payment method", e);
                 }
@@ -321,7 +321,7 @@ public class StripePaymentPluginApi extends PluginPaymentPluginApi<StripeRespons
                     // The Stripe sourceId must be passed as the PaymentMethodPlugin#getExternalPaymentMethodId
                     final Source stripeSource = Source.retrieve(paymentMethodIdInStripe, requestOptions);
                     additionalDataMap = StripePluginProperties.toAdditionalDataMap(stripeSource);
-                    stripeId = createStripeCustomer(kbAccountId, context, requestOptions, allProperties, paymentMethodIdInStripe, stripeSource.getId());
+                    stripeId = createStripeCustomer(kbAccountId, paymentMethodIdInStripe, stripeSource.getId(), requestOptions, allProperties, context);
                 } catch (final StripeException e) {
                     throw new PaymentPluginApiException("Error calling Stripe while adding payment method", e);
                 }

--- a/src/main/java/org/killbill/billing/plugin/stripe/StripePaymentPluginApi.java
+++ b/src/main/java/org/killbill/billing/plugin/stripe/StripePaymentPluginApi.java
@@ -353,9 +353,12 @@ public class StripePaymentPluginApi extends PluginPaymentPluginApi<StripeRespons
     }
 
 
-    private String createStripeCustomer(final UUID kbAccountId, final CallContext context, final RequestOptions requestOptions,
-        final Iterable<PluginProperty> allProperties, String paymentMethodIdInStripe, final String defaultStripeId)
-        throws StripeException, PaymentPluginApiException {
+    private String createStripeCustomer(final UUID kbAccountId,
+                                        final String paymentMethodIdInStripe,
+                                        final String defaultStripeId,
+                                        final RequestOptions requestOptions,
+                                        final Iterable<PluginProperty> allProperties,
+                                        final CallContext context) throws StripeException, PaymentPluginApiException {
       final String stripeId;
       final String existingCustomerId = getCustomerIdNoException(kbAccountId, context);
       final String createStripeCustomerProperty = PluginProperties.findPluginPropertyValue("createStripeCustomer", allProperties);
@@ -384,7 +387,7 @@ public class StripePaymentPluginApi extends PluginPaymentPluginApi<StripeRespons
               throw new PaymentPluginApiException("Unable to add custom field", e);
           }
       } else {
-          // The id to charge is the one-time token
+          // Stripe Customer exists OR creation is disabled: in those cases use the default ID to charge
           stripeId = defaultStripeId;
       }
       return stripeId;

--- a/src/main/java/org/killbill/billing/plugin/stripe/StripePaymentPluginApi.java
+++ b/src/main/java/org/killbill/billing/plugin/stripe/StripePaymentPluginApi.java
@@ -244,10 +244,16 @@ public class StripePaymentPluginApi extends PluginPaymentPluginApi<StripeRespons
         String paymentMethodIdInStripe = paymentMethodProps.getExternalPaymentMethodId();
         String objectType = PluginProperties.getValue("object", "payment_method", allProperties);
         if (paymentMethodIdInStripe == null) {
-            // Support also a token plugin property as it is a bit easier to pass it in cURLs (also sent by kbcmd in the body)
-            paymentMethodIdInStripe = PluginProperties.findPluginPropertyValue("token", allProperties);
+            // Support also a source plugin property as it is a easier to pass it in cURLs and recommended by Stripe
+            paymentMethodIdInStripe = PluginProperties.findPluginPropertyValue("source", allProperties);
             if (paymentMethodIdInStripe != null) {
-                objectType = "token";
+                objectType = "source";
+            } else {
+                // Support also a token plugin property as it is a bit easier to pass it in cURLs (also sent by kbcmd in the body)
+                paymentMethodIdInStripe = PluginProperties.findPluginPropertyValue("token", allProperties);
+                if (paymentMethodIdInStripe != null) {
+                    objectType = "token";
+                }
             } // Otherwise, defaults to payment_method (session flow)
         }
 
@@ -306,37 +312,7 @@ public class StripePaymentPluginApi extends PluginPaymentPluginApi<StripeRespons
                 try {
                     final Token stripeToken = Token.retrieve(paymentMethodIdInStripe, requestOptions);
                     additionalDataMap = StripePluginProperties.toAdditionalDataMap(stripeToken);
-
-                    final String existingCustomerId = getCustomerIdNoException(kbAccountId, context);
-                    final String createStripeCustomerProperty = PluginProperties.findPluginPropertyValue("createStripeCustomer", allProperties);
-                    if (existingCustomerId == null && (createStripeCustomerProperty == null || Boolean.parseBoolean(createStripeCustomerProperty))) {
-                        final Account account = getAccount(kbAccountId, context);
-
-                        final Map<String, Object> customerParams = new HashMap<>();
-                        customerParams.put("source", paymentMethodIdInStripe);
-                        customerParams.put("metadata", ImmutableMap.of("kbAccountId", kbAccountId,
-                                                                       "kbAccountExternalKey", account.getExternalKey()));
-
-                        logger.info("Creating customer in Stripe to be able to re-use the token");
-                        final Customer customer = Customer.create(customerParams, requestOptions);
-                        // The id to charge now is the default source (e.g. card), not the token
-                        stripeId = customer.getDefaultSource();
-                        // Add magic custom field
-                        logger.info("Mapping kbAccountId {} to Stripe customer {}", kbAccountId, customer.getId());
-                        final CustomField customField = new PluginCustomField(kbAccountId,
-                                                                              ObjectType.ACCOUNT,
-                                                                              "STRIPE_CUSTOMER_ID",
-                                                                              customer.getId(),
-                                                                              clock.getUTCNow());
-                        try {
-                            killbillAPI.getCustomFieldUserApi().addCustomFields(ImmutableList.<CustomField>of(customField), context);
-                        } catch (final CustomFieldApiException e) {
-                            throw new PaymentPluginApiException("Unable to add custom field", e);
-                        }
-                    } else {
-                        // The id to charge is the one-time token
-                        stripeId = stripeToken.getId();
-                    }
+                    stripeId = createStripeCustomer(kbAccountId, context, requestOptions, allProperties, paymentMethodIdInStripe, stripeToken.getId());
                 } catch (final StripeException e) {
                     throw new PaymentPluginApiException("Error calling Stripe while adding payment method", e);
                 }
@@ -345,7 +321,7 @@ public class StripePaymentPluginApi extends PluginPaymentPluginApi<StripeRespons
                     // The Stripe sourceId must be passed as the PaymentMethodPlugin#getExternalPaymentMethodId
                     final Source stripeSource = Source.retrieve(paymentMethodIdInStripe, requestOptions);
                     additionalDataMap = StripePluginProperties.toAdditionalDataMap(stripeSource);
-                    stripeId = stripeSource.getId();
+                    stripeId = createStripeCustomer(kbAccountId, context, requestOptions, allProperties, paymentMethodIdInStripe, stripeSource.getId());
                 } catch (final StripeException e) {
                     throw new PaymentPluginApiException("Error calling Stripe while adding payment method", e);
                 }
@@ -374,6 +350,44 @@ public class StripePaymentPluginApi extends PluginPaymentPluginApi<StripeRespons
         } catch (final SQLException e) {
             throw new PaymentPluginApiException("Unable to add payment method", e);
         }
+    }
+
+
+    private String createStripeCustomer(final UUID kbAccountId, final CallContext context, final RequestOptions requestOptions,
+        final Iterable<PluginProperty> allProperties, String paymentMethodIdInStripe, final String defaultStripeId)
+        throws StripeException, PaymentPluginApiException {
+      final String stripeId;
+      final String existingCustomerId = getCustomerIdNoException(kbAccountId, context);
+      final String createStripeCustomerProperty = PluginProperties.findPluginPropertyValue("createStripeCustomer", allProperties);
+      if (existingCustomerId == null && (createStripeCustomerProperty == null || Boolean.parseBoolean(createStripeCustomerProperty))) {
+          final Account account = getAccount(kbAccountId, context);
+
+          final Map<String, Object> customerParams = new HashMap<>();
+          customerParams.put("source", paymentMethodIdInStripe);
+          customerParams.put("metadata", ImmutableMap.of("kbAccountId", kbAccountId,
+                                                         "kbAccountExternalKey", account.getExternalKey()));
+
+          logger.info("Creating customer in Stripe to be able to re-use the token");
+          final Customer customer = Customer.create(customerParams, requestOptions);
+          // The id to charge now is the default source (e.g. card), not the token
+          stripeId = customer.getDefaultSource();
+          // Add magic custom field
+          logger.info("Mapping kbAccountId {} to Stripe customer {}", kbAccountId, customer.getId());
+          final CustomField customField = new PluginCustomField(kbAccountId,
+                                                                ObjectType.ACCOUNT,
+                                                                "STRIPE_CUSTOMER_ID",
+                                                                customer.getId(),
+                                                                clock.getUTCNow());
+          try {
+              killbillAPI.getCustomFieldUserApi().addCustomFields(ImmutableList.<CustomField>of(customField), context);
+          } catch (final CustomFieldApiException e) {
+              throw new PaymentPluginApiException("Unable to add custom field", e);
+          }
+      } else {
+          // The id to charge is the one-time token
+          stripeId = defaultStripeId;
+      }
+      return stripeId;
     }
 
     @Override


### PR DESCRIPTION
I want to add a SEPA debit payment method in an easy way like you can do with a Credit Card Token

The current implementation is enhanced by allowing the user to pass a Stripe **source** ID of the form _src_xxxx_ 

The unit test added allows to test the addition of a SEPA debit bank account and execute 2 payments

As per Stripe documentation 
> Source objects allow you to accept a variety of payment methods. They represent a customer's payment instrument

So using sources we can add as well other form of payments like GooglePay, ApplePay, AliPay, vouchers, etc...