### PR TITLE
Coherent Stripe customer creation process

### DIFF
--- a/src/main/java/org/killbill/billing/plugin/stripe/StripePaymentPluginApi.java
+++ b/src/main/java/org/killbill/billing/plugin/stripe/StripePaymentPluginApi.java
@@ -299,13 +299,15 @@ public class StripePaymentPluginApi extends PluginPaymentPluginApi<StripeRespons
 
         final Map<String, Object> additionalDataMap;
         final String stripeId;
+        final String existingCustomerId = getCustomerIdNoException(kbAccountId, context);
         if (paymentMethodIdInStripe != null) {
             if ("payment_method".equals(objectType)) {
                 try {
                     final PaymentMethod stripePaymentMethod = PaymentMethod.retrieve(paymentMethodIdInStripe, requestOptions);
                     additionalDataMap = StripePluginProperties.toAdditionalDataMap(stripePaymentMethod);
-                    ImmutableMap<String, Object> params = ImmutableMap.of("payment_method", paymentMethodIdInStripe);
-                    stripeId = createStripeCustomer(kbAccountId, paymentMethodIdInStripe, stripePaymentMethod.getId(), params, requestOptions, allProperties, context);
+                    ImmutableMap<String, Object> params = ImmutableMap.of("payment_method", stripePaymentMethod.getId());
+                    createStripeCustomer(kbAccountId, existingCustomerId, params, requestOptions, allProperties, context);
+                    stripeId = stripePaymentMethod.getId();
                 } catch (final StripeException e) {
                     throw new PaymentPluginApiException("Error calling Stripe while adding payment method", e);
                 }
@@ -313,8 +315,9 @@ public class StripePaymentPluginApi extends PluginPaymentPluginApi<StripeRespons
                 try {
                     final Token stripeToken = Token.retrieve(paymentMethodIdInStripe, requestOptions);
                     additionalDataMap = StripePluginProperties.toAdditionalDataMap(stripeToken);
-                    ImmutableMap<String, Object> params = ImmutableMap.of("source", paymentMethodIdInStripe);
-                    stripeId = createStripeCustomer(kbAccountId, paymentMethodIdInStripe, stripeToken.getId(), params, requestOptions, allProperties, context);
+                    ImmutableMap<String, Object> params = ImmutableMap.of("source", stripeToken.getId());
+                    String customerId = createStripeCustomer(kbAccountId, existingCustomerId, params, requestOptions, allProperties, context);
+                    stripeId = retrievePaymentMethod(customerId, existingCustomerId, stripeToken.getId(), requestOptions);
                 } catch (final StripeException e) {
                     throw new PaymentPluginApiException("Error calling Stripe while adding payment method", e);
                 }
@@ -323,15 +326,15 @@ public class StripePaymentPluginApi extends PluginPaymentPluginApi<StripeRespons
                     // The Stripe sourceId must be passed as the PaymentMethodPlugin#getExternalPaymentMethodId
                     final Source stripeSource = Source.retrieve(paymentMethodIdInStripe, requestOptions);
                     additionalDataMap = StripePluginProperties.toAdditionalDataMap(stripeSource);
-                    ImmutableMap<String, Object> params = ImmutableMap.of("source", paymentMethodIdInStripe);
-                    stripeId = createStripeCustomer(kbAccountId, paymentMethodIdInStripe, stripeSource.getId(), params, requestOptions, allProperties, context);
+                    ImmutableMap<String, Object> params = ImmutableMap.of("source", stripeSource.getId());
+                    createStripeCustomer(kbAccountId, existingCustomerId, params, requestOptions, allProperties, context);
+                    stripeId = stripeSource.getId();
                 } catch (final StripeException e) {
                     throw new PaymentPluginApiException("Error calling Stripe while adding payment method", e);
                 }
             } else if ("bank_account".equals(objectType)) {
                 try {
                     // The Stripe bankAccountId must be passed as the PaymentMethodPlugin#getExternalPaymentMethodId
-                    final String existingCustomerId = getCustomerId(kbAccountId, context);
                     final PaymentSource paymentSource = Customer.retrieve(existingCustomerId, expandSourcesParams, requestOptions)
                                                                 .getSources()
                                                                 .retrieve(paymentMethodIdInStripe, requestOptions);
@@ -356,47 +359,66 @@ public class StripePaymentPluginApi extends PluginPaymentPluginApi<StripeRespons
     }
 
     private String createStripeCustomer(final UUID kbAccountId,
-                                        final String paymentMethodIdInStripe,
-                                        final String defaultStripeId,
+                                        final String existingCustomerId,
                                         final ImmutableMap<String, Object> customerParams,
                                         final RequestOptions requestOptions,
                                         final Iterable<PluginProperty> allProperties,
                                         final CallContext context) throws StripeException, PaymentPluginApiException {
-      final String stripeId;
-      final String existingCustomerId = getCustomerIdNoException(kbAccountId, context);
-      final String createStripeCustomerProperty = PluginProperties.findPluginPropertyValue("createStripeCustomer", allProperties);
-      if (existingCustomerId == null && (createStripeCustomerProperty == null || Boolean.parseBoolean(createStripeCustomerProperty))) {
-          final Account account = getAccount(kbAccountId, context);
+        final String createStripeCustomerProperty = PluginProperties.findPluginPropertyValue("createStripeCustomer", allProperties);
 
-          final Map<String, Object> params = new HashMap<>(customerParams);
-          params.put("metadata", ImmutableMap.of("kbAccountId", kbAccountId,
-                                                 "kbAccountExternalKey", account.getExternalKey()));
+        if (existingCustomerId == null && (createStripeCustomerProperty == null || Boolean.parseBoolean(createStripeCustomerProperty))) {
+            final Account account = getAccount(kbAccountId, context);
 
-          logger.info("Creating customer in Stripe to be able to re-use the token");
-          final Customer customer = Customer.create(params, requestOptions);
-          // The id to charge now is the default source (e.g. card), not the token
-          if (customer.getDefaultSource() == null) {
-            stripeId = paymentMethodIdInStripe;
-          } else {
-            stripeId = customer.getDefaultSource();
-          }
-          // Add magic custom field
-          logger.info("Mapping kbAccountId {} to Stripe customer {}", kbAccountId, customer.getId());
-          final CustomField customField = new PluginCustomField(kbAccountId,
-                                                                ObjectType.ACCOUNT,
-                                                                "STRIPE_CUSTOMER_ID",
-                                                                customer.getId(),
-                                                                clock.getUTCNow());
-          try {
-              killbillAPI.getCustomFieldUserApi().addCustomFields(ImmutableList.<CustomField>of(customField), context);
-          } catch (final CustomFieldApiException e) {
-              throw new PaymentPluginApiException("Unable to add custom field", e);
-          }
-      } else {
-          // Stripe Customer exists OR creation is disabled: in those cases use the default ID to charge
-          stripeId = defaultStripeId;
-      }
-      return stripeId;
+            // add new customer to stripe account
+            final Map<String, Object> address = new HashMap<>();
+            address.put("city", account.getCity());
+            address.put("country", account.getCountry());
+            address.put("line1", account.getAddress1());
+            address.put("line2", account.getAddress2());
+            address.put("postal_code", account.getPostalCode());
+            address.put("state", account.getStateOrProvince());
+
+            final Map<String, Object> params = new HashMap<>(customerParams);
+            params.put("metadata", ImmutableMap.of("kbAccountId", kbAccountId,
+                                                    "kbAccountExternalKey", account.getExternalKey()));
+            params.put("email", account.getEmail());
+            params.put("name", account.getName());
+            params.put("address", address);
+            params.put("description", "created via KB");
+        
+            // Stripe Customer creation
+            logger.info("Creating customer in Stripe to be able to re-use the payment method");
+            final Customer customer = Customer.create(params, requestOptions);
+
+            // Add magic custom field
+            logger.info("Mapping kbAccountId {} to Stripe customer {}", kbAccountId, customer.getId());
+            final CustomField customField = new PluginCustomField(kbAccountId,
+                                                                    ObjectType.ACCOUNT,
+                                                                    "STRIPE_CUSTOMER_ID",
+                                                                    customer.getId(),
+                                                                    clock.getUTCNow());
+            try {
+                killbillAPI.getCustomFieldUserApi().addCustomFields(ImmutableList.<CustomField>of(customField), context);
+            } catch (final CustomFieldApiException e) {
+                throw new PaymentPluginApiException("Unable to add custom field", e);
+            }
+
+            return customer.getId();
+        } else {
+            // Stripe Customer exists OR creation is disabled: in those cases use the default ID to charge
+            return existingCustomerId;
+        }
+    }
+
+    private String retrievePaymentMethod(final String customerId, final String existingCustomerId, final String defaultStripeId, final RequestOptions requestOptions) throws StripeException, PaymentPluginApiException {
+        // The id to charge now is the default source (e.g. card), not the token
+        if (existingCustomerId == null && customerId != null) {
+            String defaultSource = Customer.retrieve(customerId, requestOptions).getDefaultSource();
+            if (defaultSource != null) {
+                return defaultSource;
+            }
+        }
+        return defaultStripeId;
     }
 
     @Override
@@ -686,29 +708,11 @@ public class StripePaymentPluginApi extends PluginPaymentPluginApi<StripeRespons
     public HostedPaymentPageFormDescriptor buildFormDescriptor(final UUID kbAccountId, final Iterable<PluginProperty> customFields, final Iterable<PluginProperty> properties, final CallContext context) throws PaymentPluginApiException {
         final RequestOptions requestOptions = buildRequestOptions(context);
 
-        final Account account = getAccount(kbAccountId, context);
-
         String stripeCustomerId = getCustomerIdNoException(kbAccountId, context);
-        if (stripeCustomerId == null) {
-            // add new customer to stripe account
-            Map<String, Object> address = new HashMap<>();
-            address.put("city", account.getCity());
-            address.put("country", account.getCountry());
-            address.put("line1", account.getAddress1());
-            address.put("line2", account.getAddress2());
-            address.put("postal_code", account.getPostalCode());
-            address.put("state", account.getStateOrProvince());
-            Map<String, Object> params = new HashMap<>();
-            params.put("email", account.getEmail());
-            params.put("name", account.getName());
-            params.put("address", address);
-            params.put("description", "created via KB");
-            try {
-                Customer customer = Customer.create(params, requestOptions);
-                stripeCustomerId = customer.getId();
-            } catch (StripeException e) {
-                throw new PaymentPluginApiException("Unable to create Stripe customer", e);
-            }
+        try {
+            stripeCustomerId = createStripeCustomer(kbAccountId, stripeCustomerId, null, requestOptions, properties, context);
+        } catch (StripeException e) {
+            throw new PaymentPluginApiException("Unable to create Stripe customer", e);
         }
 
         final Map<String, Object> params = new HashMap<String, Object>();

--- a/src/main/java/org/killbill/billing/plugin/stripe/StripePluginProperties.java
+++ b/src/main/java/org/killbill/billing/plugin/stripe/StripePluginProperties.java
@@ -293,8 +293,6 @@ public abstract class StripePluginProperties {
         additionalDataMap.put("success_url", session.getSuccessUrl());
         if (pk != null) {
             additionalDataMap.put("publishable_key", pk);
-            additionalDataMap.put("setup_intent_client_secret", session.getSetupIntentObject().getClientSecret());
-            additionalDataMap.put("payment_intent_client_secret", session.getPaymentIntentObject().getClientSecret());
         }
 
         return additionalDataMap;

--- a/src/main/java/org/killbill/billing/plugin/stripe/StripePluginProperties.java
+++ b/src/main/java/org/killbill/billing/plugin/stripe/StripePluginProperties.java
@@ -289,6 +289,7 @@ public abstract class StripePluginProperties {
         additionalDataMap.put("payment_intent_id", session.getPaymentIntent());
         additionalDataMap.put("payment_method_types", session.getPaymentMethodTypes());
         additionalDataMap.put("setup_intent_id", session.getSetupIntent());
+        additionalDataMap.put("client_secret", session.getSetupIntentObject().getClientSecret());
         additionalDataMap.put("subscription_id", session.getSubscription());
         additionalDataMap.put("success_url", session.getSuccessUrl());
         if (pk != null) {

--- a/src/main/java/org/killbill/billing/plugin/stripe/StripePluginProperties.java
+++ b/src/main/java/org/killbill/billing/plugin/stripe/StripePluginProperties.java
@@ -289,11 +289,12 @@ public abstract class StripePluginProperties {
         additionalDataMap.put("payment_intent_id", session.getPaymentIntent());
         additionalDataMap.put("payment_method_types", session.getPaymentMethodTypes());
         additionalDataMap.put("setup_intent_id", session.getSetupIntent());
-        additionalDataMap.put("client_secret", session.getSetupIntentObject().getClientSecret());
         additionalDataMap.put("subscription_id", session.getSubscription());
         additionalDataMap.put("success_url", session.getSuccessUrl());
         if (pk != null) {
             additionalDataMap.put("publishable_key", pk);
+            additionalDataMap.put("setup_intent_client_secret", session.getSetupIntentObject().getClientSecret());
+            additionalDataMap.put("payment_intent_client_secret", session.getPaymentIntentObject().getClientSecret());
         }
 
         return additionalDataMap;


### PR DESCRIPTION
I used for the first time the **checkout** endpoint and the Stripe customer was created with different attributes respect the usage of tokens/sources.

With this PR I want only to use the same function **createStripeCustomer** in every use case and ensure a coherent Customer creation for every usage.

I tested and there is no notable behavior change.

I hope to not overload your daily workload and hopfully this can be easy to integrate