### PR TITLE
Fix null pointer exception

### DIFF
--- a/src/main/java/org/killbill/billing/plugin/stripe/StripePaymentPluginApi.java
+++ b/src/main/java/org/killbill/billing/plugin/stripe/StripePaymentPluginApi.java
@@ -757,8 +757,12 @@ public class StripePaymentPluginApi extends PluginPaymentPluginApi<StripeRespons
                               clock.getUTCNow(),
                               context.getTenantId());
             final Map<String, Object> additionalDataMap = StripePluginProperties.toAdditionalDataMap(session, stripeConfigProperties.getPublicKey());
-            additionalDataMap.put("setup_intent_client_secret", session.getSetupIntentObject().getClientSecret());
-            additionalDataMap.put("payment_intent_client_secret", session.getPaymentIntentObject().getClientSecret());
+            if (session != null && session.getSetupIntentObject() != null) {
+                additionalDataMap.put("setup_intent_client_secret", session.getSetupIntentObject().getClientSecret());
+            }
+            if (session != null && session.getPaymentIntentObject() != null) {
+                additionalDataMap.put("payment_intent_client_secret", session.getPaymentIntentObject().getClientSecret());
+            }
             return new PluginHostedPaymentPageFormDescriptor(kbAccountId, null, PluginProperties.buildPluginProperties(additionalDataMap));
         } catch (final StripeException e) {
             throw new PaymentPluginApiException("Unable to create Stripe session", e);

--- a/src/main/java/org/killbill/billing/plugin/stripe/StripePaymentPluginApi.java
+++ b/src/main/java/org/killbill/billing/plugin/stripe/StripePaymentPluginApi.java
@@ -20,6 +20,7 @@ package org.killbill.billing.plugin.stripe;
 import java.math.BigDecimal;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -721,7 +722,7 @@ public class StripePaymentPluginApi extends PluginPaymentPluginApi<StripeRespons
 
         String stripeCustomerId = getCustomerIdNoException(kbAccountId, context);
         try {
-            stripeCustomerId = createStripeCustomer(kbAccountId, stripeCustomerId, null, requestOptions, properties, context);
+            stripeCustomerId = createStripeCustomer(kbAccountId, stripeCustomerId, ImmutableMap.of(), requestOptions, properties, context);
         } catch (StripeException e) {
             throw new PaymentPluginApiException("Unable to create Stripe customer", e);
         }
@@ -742,6 +743,7 @@ public class StripePaymentPluginApi extends PluginPaymentPluginApi<StripeRespons
         params.put("payment_method_types", customPaymentMethods != null && customPaymentMethods.getValue() != null ? customPaymentMethods.getValue() : defaultPaymentMethodTypes);
 
         params.put("mode", "setup");
+        params.put("expand", Arrays.asList("setup_intent", "payment_intent"));
         params.put("success_url", PluginProperties.getValue("success_url", "https://example.com/success?sessionId={CHECKOUT_SESSION_ID}", customFields));
         params.put("cancel_url", PluginProperties.getValue("cancel_url", "https://example.com/cancel", customFields));
         final StripeConfigProperties stripeConfigProperties = stripeConfigPropertiesConfigurationHandler.getConfigurable(context.getTenantId());

--- a/src/test/java/org/killbill/billing/plugin/stripe/TestStripePaymentPluginApi.java
+++ b/src/test/java/org/killbill/billing/plugin/stripe/TestStripePaymentPluginApi.java
@@ -726,7 +726,7 @@ public class TestStripePaymentPluginApi extends TestBase {
 
         // Still no payment method
         assertEquals(stripePaymentPluginApi.getPaymentMethods(kbAccountId, false, ImmutableList.<PluginProperty>of(), context).size(), 0);
-        assertEquals(killbillApi.getCustomFieldUserApi().getCustomFieldsForAccountType(kbAccountId, ObjectType.ACCOUNT, context).size(), 0);
+        assertEquals(killbillApi.getCustomFieldUserApi().getCustomFieldsForAccountType(kbAccountId, ObjectType.ACCOUNT, context).size(), 1);
 
         final UUID kbPaymentMethodId = UUID.randomUUID();
         stripePaymentPluginApi.addPaymentMethod(kbAccountId,

--- a/src/test/java/org/killbill/billing/plugin/stripe/TestStripePaymentPluginApi.java
+++ b/src/test/java/org/killbill/billing/plugin/stripe/TestStripePaymentPluginApi.java
@@ -24,6 +24,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
 
 import org.asynchttpclient.BoundRequestBuilder;
 import org.joda.time.Period;
@@ -715,6 +717,8 @@ public class TestStripePaymentPluginApi extends TestBase {
                                                                                                                            customFields,
                                                                                                                            ImmutableList.of(),
                                                                                                                            context);
+        assertEquals(hostedPaymentPageFormDescriptor.getFormFields().stream().filter(item -> item.getKey().equals("setup_intent_client_secret")).collect(Collectors.toList()).size(), 1);
+
         final String sessionId = PluginProperties.findPluginPropertyValue("id", hostedPaymentPageFormDescriptor.getFormFields());
         assertNotNull(sessionId);
 


### PR DESCRIPTION
```
{"@timestamp":"2022-10-27T09:18:21.348Z","message":"execution of: POST/checkout resulted in exception\nRoute:\n      | Method | Path      | Source                                                      | Name                                 | Pattern   | Consumes | Produces |\n      |--------|-----------|-------------------------------------------------------------|--------------------------------------|-----------|----------|----------|\n      | POST   | /checkout | org.killbill.billing.plugin.stripe.StripeCheckoutServlet:68 | /StripeCheckoutServlet.createSession | /checkout | [*/*]    | [*/*]    |\n\nStacktrace:","logger_name":"org.jooby.Err","thread_name":"catalina-exec-4","level":"ERROR","req.requestURI":"/plugins/killbill-stripe/checkout","req.queryString":"kbAccountId=ace32ae4-4e41-450c-98ab-13a425c64679&paymentMethodTypes=sepa_debit&paymentMethodTypes=card","kb.tenantRecordId":"1","req.requestId":"907dc0f6-2101-428e-852d-33c6ed70e262","req.method":"POST","kb.accountRecordId":"2","req.remoteHost":"10.233.89.229","req.requestURL":"http://kill-bill-cloud-services.hdp-management/plugins/killbill-stripe/checkout","req.userAgent":"KillBill-JavaClient/1.0","stack_trace":"org.jooby.Err: Server Error(500)
	at org.jooby.internal.HttpHandlerImpl.handleErr(HttpHandlerImpl.java:589)
	at org.jooby.internal.HttpHandlerImpl.cleanup(HttpHandlerImpl.java:562)
	at org.jooby.internal.HttpHandlerImpl.handle(HttpHandlerImpl.java:504)
....
....
	at java.lang.Thread.run(Thread.java:748)\nCaused by: java.lang.NullPointerException: null
	at org.killbill.billing.plugin.stripe.StripePaymentPluginApi.buildFormDescriptor(StripePaymentPluginApi.java:760)
	at org.killbill.billing.plugin.stripe.StripeCheckoutServlet.createSession(StripeCheckoutServlet.java:76)
....
```