### PR TITLE
Use of the statement_descriptor parameter on PaymentIntents for card charges

### DIFF
--- a/src/main/java/org/killbill/billing/plugin/stripe/StripePaymentPluginApi.java
+++ b/src/main/java/org/killbill/billing/plugin/stripe/StripePaymentPluginApi.java
@@ -887,7 +887,7 @@ public class StripePaymentPluginApi extends PluginPaymentPluginApi<StripeRespons
 
                                                  final StripeConfigProperties stripeConfigProperties = stripeConfigPropertiesConfigurationHandler.getConfigurable(context.getTenantId());
                                                  paymentIntentParams.put("description", stripeConfigProperties.getChargeDescription());
-                                                 paymentIntentParams.put("statement_descriptor", stripeConfigProperties.getChargeStatementDescriptor());
+                                                 paymentIntentParams.put("statement_descriptor_suffix", stripeConfigProperties.getChargeStatementDescriptor());
 
                                                  logger.info("Creating Stripe PaymentIntent");
                                                  return PaymentIntent.create(paymentIntentParams, requestOptions);


### PR DESCRIPTION
According to [Stripe announcement](https://support.stripe.com/questions/use-of-the-statement-descriptor-parameter-on-paymentintents-for-card-charges):

Statement descriptors explain charges or payments on bank statements. Using clear and accurate statement descriptors can reduce chargebacks and disputes. Banks and card networks require the inclusion of certain types of information that help customers understand their statements, and statement descriptors provide this information. Read our [documentation](https://stripe.com/docs/payments/account/statement-descriptors) for more detailed information regarding statement descriptors.

As of **02/01/2024**, Stripe no longer supports the `statement_descriptor` parameter on the PaymentIntent API for PaymentIntents in which one of the supported `payment_method_types` is `card`. Attempting to set a statement_descriptor on a PaymentIntent with a `card` as one of the payment_method_types will result in a 400 error code. For these requests, please use the `statement_descriptor_suffix` instead.

In this PR I have not changed the plugin property and only the parameter passed to the PaymentIntent request. This way the change is backwards compatible and won't require major version bump. I also didn't separate support for `statement_descriptor` for payments without cards as it seems cards are "hardcoded".