### PR TITLE
Encrypt Stripe API keys at rest with AES-256-GCM

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,47 @@ org.killbill.billing.plugin.stripe.chargeStatementDescriptor=ZZZ' \
      http://127.0.0.1:8080/1.0/kb/tenants/uploadPluginConfig/killbill-stripe
 ```
 
+## Securing API Keys
+
+By default, API keys are stored in plaintext in Kill Bill's tenant configuration. You can secure them using environment variable references or encrypted values.
+
+### Environment variable references (recommended for K8s/Docker)
+
+Store your Stripe keys in environment variables and reference them in the plugin config:
+
+```
+org.killbill.billing.plugin.stripe.apiKey=${env:STRIPE_API_KEY}
+org.killbill.billing.plugin.stripe.publicKey=${env:STRIPE_PUBLIC_KEY}
+```
+
+This way, secrets never enter the database and can be managed by your orchestration layer (K8s Secrets, HashiCorp Vault, AWS SSM, etc.).
+
+### Encrypted values (for multi-tenant DB storage)
+
+For multi-tenant setups where per-tenant environment variables are impractical, you can store AES-256-GCM encrypted values using the `ENC()` wrapper (consistent with Kill Bill core's convention):
+
+1. Generate a 256-bit encryption key:
+   ```bash
+   openssl rand -base64 32
+   ```
+
+2. Make the key available to the JVM via environment variable or system property:
+   ```bash
+   export KILLBILL_STRIPE_ENCRYPTION_KEY=<base64-key-from-step-1>
+   ```
+   Or as a system property: `-Dorg.killbill.billing.plugin.stripe.encryptionKey=<base64-key>`
+
+3. Encrypt your API key using the `StripeConfigPropertyResolver.encrypt()` utility and wrap it:
+   ```
+   org.killbill.billing.plugin.stripe.apiKey=ENC(<base64-encrypted-value>)
+   ```
+
+Each tenant can have a different encrypted value while sharing the same JVM-level encryption key.
+
+### Migration note
+
+Existing plaintext configurations continue to work with zero changes. Encryption is fully opt-in.
+
 ## Payment Method flow
 
 To charge a payment instrument (card, bank account, etc.), you first need to collect the payment instrument details in Stripe and create an associated payment method in Kill Bill.

--- a/src/main/java/org/killbill/billing/plugin/stripe/StripeConfigProperties.java
+++ b/src/main/java/org/killbill/billing/plugin/stripe/StripeConfigProperties.java
@@ -77,8 +77,8 @@ public class StripeConfigProperties {
 
     public StripeConfigProperties(final Properties properties, final String region) {
         this.region = region;
-        this.apiKey = properties.getProperty(PROPERTY_PREFIX + "apiKey");
-        this.publicKey = properties.getProperty(PROPERTY_PREFIX + "publicKey");
+        this.apiKey = StripeConfigPropertyResolver.resolve(properties.getProperty(PROPERTY_PREFIX + "apiKey"));
+        this.publicKey = StripeConfigPropertyResolver.resolve(properties.getProperty(PROPERTY_PREFIX + "publicKey"));
         this.apiBase = properties.getProperty(PROPERTY_PREFIX + "apiBase");
         this.proxyHost = properties.getProperty(PROPERTY_PREFIX + "proxyHost");
         this.proxyPort = Integer.parseInt(properties.getProperty(PROPERTY_PREFIX + "proxyPort", "-1"));

--- a/src/main/java/org/killbill/billing/plugin/stripe/StripeConfigPropertyResolver.java
+++ b/src/main/java/org/killbill/billing/plugin/stripe/StripeConfigPropertyResolver.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2020-2020 Equinix, Inc
+ * Copyright 2014-2020 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.killbill.billing.plugin.stripe;
+
+import java.nio.ByteBuffer;
+import java.security.SecureRandom;
+import java.util.Base64;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.annotation.Nullable;
+import javax.crypto.Cipher;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+
+/**
+ * Resolves config property values that may be plaintext, encrypted ({@code ENC(base64)}),
+ * or environment variable references ({@code ${env:VAR_NAME}}).
+ *
+ * <ul>
+ *   <li><b>Plaintext</b> — returned as-is (backward compatible)</li>
+ *   <li><b>{@code ENC(base64)}</b> — decrypted with AES-256-GCM using a key from
+ *       system property {@code org.killbill.billing.plugin.stripe.encryptionKey}
+ *       or env var {@code KILLBILL_STRIPE_ENCRYPTION_KEY} (Base64-encoded 256-bit key)</li>
+ *   <li><b>{@code ${env:VAR_NAME}}</b> — resolved via {@link System#getenv(String)}</li>
+ * </ul>
+ */
+public class StripeConfigPropertyResolver {
+
+    private static final Pattern ENC_PATTERN = Pattern.compile("^ENC\\(([A-Za-z0-9+/=]+)\\)$");
+    private static final Pattern ENV_PATTERN = Pattern.compile("^\\$\\{env:([^}]+)}$");
+
+    private static final String SYSTEM_PROPERTY_KEY = "org.killbill.billing.plugin.stripe.encryptionKey";
+    private static final String ENV_VAR_KEY = "KILLBILL_STRIPE_ENCRYPTION_KEY";
+
+    private static final String ALGORITHM = "AES/GCM/NoPadding";
+    private static final int GCM_IV_LENGTH = 12;
+    private static final int GCM_TAG_BITS = 128;
+
+    /**
+     * Resolve a configuration value. Supports plaintext, {@code ENC(base64)}, and {@code ${env:VAR}}.
+     *
+     * @param value the raw property value (may be {@code null})
+     * @return the resolved plaintext value, or {@code null} if input is {@code null}
+     */
+    public static @Nullable String resolve(@Nullable final String value) {
+        if (value == null) {
+            return null;
+        }
+
+        final Matcher envMatcher = ENV_PATTERN.matcher(value);
+        if (envMatcher.matches()) {
+            final String varName = envMatcher.group(1);
+            final String envValue = resolveEnvVar(varName);
+            if (envValue == null) {
+                throw new IllegalStateException("Environment variable '" + varName + "' is not set");
+            }
+            return envValue;
+        }
+
+        final Matcher encMatcher = ENC_PATTERN.matcher(value);
+        if (encMatcher.matches()) {
+            return decrypt(encMatcher.group(1));
+        }
+
+        return value;
+    }
+
+    /**
+     * Encrypt a plaintext value with AES-256-GCM. The returned Base64 string contains
+     * the 12-byte IV prepended to the ciphertext and can be wrapped in {@code ENC(...)}.
+     *
+     * @param plaintext the value to encrypt
+     * @param key       a 256-bit (32-byte) AES key
+     * @return Base64-encoded IV + ciphertext
+     */
+    public static String encrypt(final String plaintext, final byte[] key) {
+        try {
+            final byte[] iv = new byte[GCM_IV_LENGTH];
+            new SecureRandom().nextBytes(iv);
+
+            final Cipher cipher = Cipher.getInstance(ALGORITHM);
+            cipher.init(Cipher.ENCRYPT_MODE, new SecretKeySpec(key, "AES"), new GCMParameterSpec(GCM_TAG_BITS, iv));
+            final byte[] ciphertext = cipher.doFinal(plaintext.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+
+            final ByteBuffer buffer = ByteBuffer.allocate(iv.length + ciphertext.length);
+            buffer.put(iv);
+            buffer.put(ciphertext);
+            return Base64.getEncoder().encodeToString(buffer.array());
+        } catch (final Exception e) {
+            throw new IllegalStateException("Encryption failed", e);
+        }
+    }
+
+    private static String decrypt(final String base64Ciphertext) {
+        try {
+            final byte[] key = getEncryptionKey();
+            final byte[] decoded = Base64.getDecoder().decode(base64Ciphertext);
+
+            final byte[] iv = new byte[GCM_IV_LENGTH];
+            System.arraycopy(decoded, 0, iv, 0, GCM_IV_LENGTH);
+
+            final Cipher cipher = Cipher.getInstance(ALGORITHM);
+            cipher.init(Cipher.DECRYPT_MODE, new SecretKeySpec(key, "AES"), new GCMParameterSpec(GCM_TAG_BITS, iv));
+            final byte[] plaintext = cipher.doFinal(decoded, GCM_IV_LENGTH, decoded.length - GCM_IV_LENGTH);
+
+            return new String(plaintext, java.nio.charset.StandardCharsets.UTF_8);
+        } catch (final IllegalStateException e) {
+            throw e;
+        } catch (final Exception e) {
+            throw new IllegalStateException("Decryption failed", e);
+        }
+    }
+
+    private static byte[] getEncryptionKey() {
+        String keyBase64 = System.getProperty(SYSTEM_PROPERTY_KEY);
+        if (keyBase64 == null || keyBase64.isEmpty()) {
+            keyBase64 = System.getenv(ENV_VAR_KEY);
+        }
+        if (keyBase64 == null || keyBase64.isEmpty()) {
+            throw new IllegalStateException(
+                    "Encryption key not configured. Set system property '" + SYSTEM_PROPERTY_KEY +
+                    "' or environment variable '" + ENV_VAR_KEY + "' to a Base64-encoded 256-bit key.");
+        }
+        return Base64.getDecoder().decode(keyBase64);
+    }
+
+    // Package-private for test overriding
+    static @Nullable String resolveEnvVar(final String name) {
+        return System.getenv(name);
+    }
+}

--- a/src/test/java/org/killbill/billing/plugin/stripe/TestStripeConfigPropertyResolver.java
+++ b/src/test/java/org/killbill/billing/plugin/stripe/TestStripeConfigPropertyResolver.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2020-2020 Equinix, Inc
+ * Copyright 2014-2020 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.killbill.billing.plugin.stripe;
+
+import java.security.SecureRandom;
+import java.util.Base64;
+import java.util.Properties;
+
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+public class TestStripeConfigPropertyResolver {
+
+    private static final String SYSTEM_PROPERTY_KEY = "org.killbill.billing.plugin.stripe.encryptionKey";
+
+    @AfterMethod(groups = "fast")
+    public void tearDown() {
+        System.clearProperty(SYSTEM_PROPERTY_KEY);
+    }
+
+    @Test(groups = "fast")
+    public void testPlaintextPassthrough() {
+        Assert.assertEquals(StripeConfigPropertyResolver.resolve("sk_test_XXX"), "sk_test_XXX");
+        Assert.assertEquals(StripeConfigPropertyResolver.resolve("plain value"), "plain value");
+        Assert.assertEquals(StripeConfigPropertyResolver.resolve(""), "");
+    }
+
+    @Test(groups = "fast")
+    public void testNullPassthrough() {
+        Assert.assertNull(StripeConfigPropertyResolver.resolve(null));
+    }
+
+    @Test(groups = "fast")
+    public void testEncryptDecryptRoundTrip() {
+        final byte[] key = generateKey();
+        System.setProperty(SYSTEM_PROPERTY_KEY, Base64.getEncoder().encodeToString(key));
+
+        final String original = "sk_live_1234567890abcdef";
+        final String encrypted = StripeConfigPropertyResolver.encrypt(original, key);
+        final String resolved = StripeConfigPropertyResolver.resolve("ENC(" + encrypted + ")");
+
+        Assert.assertEquals(resolved, original);
+    }
+
+    @Test(groups = "fast")
+    public void testEncryptionProducesDifferentCiphertexts() {
+        final byte[] key = generateKey();
+
+        final String plaintext = "sk_test_repeatable";
+        final String enc1 = StripeConfigPropertyResolver.encrypt(plaintext, key);
+        final String enc2 = StripeConfigPropertyResolver.encrypt(plaintext, key);
+
+        Assert.assertNotEquals(enc1, enc2, "Random IVs should produce different ciphertexts");
+    }
+
+    @Test(groups = "fast", expectedExceptions = IllegalStateException.class,
+          expectedExceptionsMessageRegExp = ".*Encryption key not configured.*")
+    public void testDecryptWithoutKeyFails() {
+        // Ensure no key is set
+        System.clearProperty(SYSTEM_PROPERTY_KEY);
+        // Use a valid base64 string that looks like ENC(...) — the key lookup should fail first
+        StripeConfigPropertyResolver.resolve("ENC(AQIDBAUGBwgJCgsMDQ4PEA==)");
+    }
+
+    @Test(groups = "fast", expectedExceptions = IllegalStateException.class,
+          expectedExceptionsMessageRegExp = ".*Environment variable.*is not set.*")
+    public void testEnvVarNotSetFails() {
+        // Use a var name that is extremely unlikely to exist
+        StripeConfigPropertyResolver.resolve("${env:KILLBILL_STRIPE_TEST_NONEXISTENT_VAR_12345}");
+    }
+
+    @Test(groups = "fast")
+    public void testBackwardCompatibilityWithStripeConfigProperties() {
+        final Properties properties = new Properties();
+        properties.setProperty("org.killbill.billing.plugin.stripe.apiKey", "sk_test_plaintext");
+        properties.setProperty("org.killbill.billing.plugin.stripe.publicKey", "pk_test_plaintext");
+
+        final StripeConfigProperties config = new StripeConfigProperties(properties, "");
+
+        Assert.assertEquals(config.getApiKey(), "sk_test_plaintext");
+        Assert.assertEquals(config.getPublicKey(), "pk_test_plaintext");
+    }
+
+    @Test(groups = "fast")
+    public void testEncryptedValuesInStripeConfigProperties() {
+        final byte[] key = generateKey();
+        System.setProperty(SYSTEM_PROPERTY_KEY, Base64.getEncoder().encodeToString(key));
+
+        final String apiKeyPlain = "sk_test_encrypted_api_key";
+        final String publicKeyPlain = "pk_test_encrypted_public_key";
+
+        final Properties properties = new Properties();
+        properties.setProperty("org.killbill.billing.plugin.stripe.apiKey",
+                               "ENC(" + StripeConfigPropertyResolver.encrypt(apiKeyPlain, key) + ")");
+        properties.setProperty("org.killbill.billing.plugin.stripe.publicKey",
+                               "ENC(" + StripeConfigPropertyResolver.encrypt(publicKeyPlain, key) + ")");
+
+        final StripeConfigProperties config = new StripeConfigProperties(properties, "");
+
+        Assert.assertEquals(config.getApiKey(), apiKeyPlain);
+        Assert.assertEquals(config.getPublicKey(), publicKeyPlain);
+    }
+
+    private static byte[] generateKey() {
+        final byte[] key = new byte[32];
+        new SecureRandom().nextBytes(key);
+        return key;
+    }
+}


### PR DESCRIPTION
## Summary

- Add `StripeConfigPropertyResolver` to encrypt Stripe API keys (`apiKey`, `publicKey`) at rest using AES-256-GCM, with support for environment variable references (`${env:VAR}`) and encrypted values (`ENC(base64)`)
- Existing plaintext configurations continue to work with zero changes — fully backward compatible
- Uses JDK standard crypto only (`javax.crypto`) — no new dependencies

## Problem

Stripe API keys are stored in plaintext in `tenant_kvs` when uploaded via `uploadPluginConfig`. A database compromise exposes all tenants' Stripe secret keys. No Kill Bill plugin currently encrypts tenant configuration.

## Why not reuse Jasypt?

- Jasypt (`-Djasypt.encryptor.password`) operates at the JVM system property level during KB core startup and is **not available to OSGi plugins**
- Jasypt's PBE algorithm (PBEWithSHA1AndDESede) is different from modern AES-256-GCM; reusing the same password across incompatible algorithms is a security anti-pattern
- Each KB component already manages its own keys (core: Jasypt, Kaui: `KAUI_SECRET_KEY_BASE`), so a plugin-specific key is consistent
- JDK standard crypto achieves the same goal with zero dependency overhead

## Design

Two resolution mechanisms for different deployment models:

| Mode | Syntax | Use case |
|------|--------|----------|
| **Plaintext** | `sk_test_XXX` | Existing behavior (backward compat) |
| **Env var** | `${env:STRIPE_API_KEY}` | K8s/Docker (secrets managed by orchestration) |
| **Encrypted** | `ENC(base64...)` | Multi-tenant DB storage (per-tenant encrypted values) |

**Crypto**: AES-256-GCM, 12-byte random IV (NIST recommended), 128-bit auth tag. Key from system property `org.killbill.billing.plugin.stripe.encryptionKey` or env var `KILLBILL_STRIPE_ENCRYPTION_KEY` (Base64-encoded 256-bit key, e.g. `openssl rand -base64 32`).

## Changes

| File | Change |
|------|--------|
| `StripeConfigPropertyResolver.java` | **New** — resolver utility (~120 lines) |
| `StripeConfigProperties.java` | **2 lines** — wrap `apiKey`/`publicKey` reads with `resolve()` |
| `TestStripeConfigPropertyResolver.java` | **New** — 8 TestNG tests (group `fast`) |
| `README.md` | **New section** — "Securing API Keys" documentation |

No changes to `pom.xml`, `StripeActivator`, `StripeDao`, DDL, or any other files.

## Test plan

- [x] `testPlaintextPassthrough` — raw values returned unchanged
- [x] `testNullPassthrough` — null in, null out
- [x] `testEncryptDecryptRoundTrip` — encrypt → decrypt → verify match
- [x] `testEncryptionProducesDifferentCiphertexts` — random IVs produce unique output
- [x] `testDecryptWithoutKeyFails` — `IllegalStateException` when no key configured
- [x] `testEnvVarNotSetFails` — `IllegalStateException` for missing env var
- [x] `testBackwardCompatibilityWithStripeConfigProperties` — plaintext through full constructor
- [x] `testEncryptedValuesInStripeConfigProperties` — encrypted values through full constructor

🤖 Generated with [Claude Code](https://claude.com/claude-code)